### PR TITLE
Use grain to override `oupath` from pillar

### DIFF
--- a/join-domain/elx/pbis.sls
+++ b/join-domain/elx/pbis.sls
@@ -13,6 +13,7 @@ include:
 
 # Vars used to run the domain-join actions
 {%- set join_elx = salt['pillar.get']('join-domain:linux', {}) %}
+{%- do join_elx.update(salt['grains.get']('join-domain', {})) %}
 {%- set domainFqdn = join_elx.ad_domain_fqdn %}
 {%- set domainShort = join_elx.ad_domain_short %}
 {%- set domainAcct = join_elx.join_svc_acct %}

--- a/join-domain/windows/init.sls
+++ b/join-domain/windows/init.sls
@@ -1,4 +1,5 @@
 {%- set join_domain = salt['pillar.get']('join-domain:windows', {}) %}
+{%- do join_domain.update(salt['grains.get']('join-domain', {})) %}
 
 {%- if join_domain %}
 

--- a/join-domain/windows/init.sls
+++ b/join-domain/windows/init.sls
@@ -1,7 +1,8 @@
 {%- set join_domain = salt['pillar.get']('join-domain:windows', {}) %}
-{%- do join_domain.update(salt['grains.get']('join-domain', {})) %}
 
 {%- if join_domain %}
+
+{%- do join_domain.update(salt['grains.get']('join-domain', {})) %}
 
 join standalone system to domain:
   cmd.run:


### PR DESCRIPTION
Provides a mechanism through which users can easily set the `outpath` at which an instance should be placed when it joins the domain.