### PR TITLE
Change handling for "no OU" use-case

### DIFF
--- a/join-domain/elx/files/pbis-join.sh
+++ b/join-domain/elx/files/pbis-join.sh
@@ -77,10 +77,14 @@ then
 fi
 
 # Set parms necessary to do a targeted-OU join
-if [[ ${JOINOU} != "UNDEF" ]]
-then
-   TARGOU="--ou ${JOINOU}"
-fi
+case ${JOINOU} in
+    none|None|NONE|UNDEF)
+       TARGOU=""
+       ;;
+    *)
+       TARGOU="--ou ${JOINOU}"
+       ;;
+esac
 
 
 # Execute join-attempt as necessary...


### PR DESCRIPTION
* Null values in Pillar get passed as 'None', short-circuiting the
  UNDEF logic used for setting appropriate TARGOU
* Change TARGOU logic's if statement to case to make multi-value
  matching more compact