### PR TITLE
Update nuke-logic

### DIFF
--- a/join-domain/elx/files/pbis-clndir.sh
+++ b/join-domain/elx/files/pbis-clndir.sh
@@ -69,7 +69,7 @@ function CheckMyJoinState() {
    if [[ $(rpm -q --quiet pbis-open)$? -eq 0 ]] &&
       [[ ! -e /var/lib/pbis/db/lsass-adcache.filedb.${CHKDOM} ]]
    then
-      service lwsmd restart
+      service lwsmd restart > /dev/null 2>&1
    fi
 
    # See if adcache file exists - return value if it does

--- a/join-domain/elx/files/pbis-clndir.sh
+++ b/join-domain/elx/files/pbis-clndir.sh
@@ -59,6 +59,16 @@ function PWdecrypt() {
 }
 
 
+# Am I already joined
+function CheckMyJoinState() {
+   local CHKDOM=$(echo ${DOMAIN} | tr "[:lower:]" "[:upper:]")
+   if [[ -e /var/lib/pbis/db/lsass-adcache.filedb.${CHKDOM} ]]
+   then
+      echo "LOCALLYBOUND"
+   fi
+}
+
+
 # Check for object-collisions
 function CheckObject() {
    local EXISTS=$(${ADTOOL} -d ${DOMAIN} -n ${USERID}@${DOMAIN} \
@@ -103,7 +113,13 @@ PASSWORD=$(PWdecrypt)
 if [[ $(CheckObject) = NONE ]]
 then
    printf "\n"
-   printf "changed=no comment='No collisions for ${NODENAME} found "
+   printf "changed=no comment='No collisions for ${NODENAME} found'"
+   printf "in the directory'\n"
+   exit 0
+elif [[ $(CheckMyJoinState) = "LOCALLYBOUND" ]]
+then
+   printf "\n"
+   printf "changed=no comment='Local system has active join config present'"
    printf "in the directory'\n"
    exit 0
 else

--- a/join-domain/elx/files/pbis-clndir.sh
+++ b/join-domain/elx/files/pbis-clndir.sh
@@ -62,6 +62,17 @@ function PWdecrypt() {
 # Am I already joined
 function CheckMyJoinState() {
    local CHKDOM=$(echo ${DOMAIN} | tr "[:lower:]" "[:upper:]")
+
+   # Try to accommodate back-to-back (ab)use cases
+   # This should ensure that the adcache file exists if the
+   # host is properly configured to talk to AD
+   if [[ $(rpm -q --quiet pbis-open)$? -eq 0 ]] &&
+      [[ ! -e /var/lib/pbis/db/lsass-adcache.filedb.${CHKDOM} ]]
+   then
+      service lwsmd restart
+   fi
+
+   # See if adcache file exists - return value if it does
    if [[ -e /var/lib/pbis/db/lsass-adcache.filedb.${CHKDOM} ]]
    then
       echo "LOCALLYBOUND"


### PR DESCRIPTION
* Check for presence of /var/lib/pbis/db/lsass-adcache.filedb.${FQDN}
  file.
  * If file is present, skip the nuke-step and throw explanation
  * If absent, continue with previous action-logic
* Fixes #45

Note: if state is run iteratively without the `lwsmd` service being
      restarted, this logic may not prevent spurious nuking. Restarting
      the `lwsmd` service (and other cache-triggering events) create
      the checked-for lsass-adcache.filedb.${FQDN} file.