### PR TITLE
Join domain with new name

### DIFF
--- a/join-domain/windows/init.sls
+++ b/join-domain/windows/init.sls
@@ -36,10 +36,11 @@ join standalone system to domain:
           -AsPlainText -Force);
     {%- if join_domain.oupath -%}
         Add-Computer -DomainName {{ join_domain.domain_name }} -Credential $cred
-          -Force -OUPath "{{ join_domain.oupath }}" -ErrorAction Stop;
+          -OUPath "{{ join_domain.oupath }}"
+          -Options JoinWithNewName,AccountCreate -Force -ErrorAction Stop;
     {%- else -%}
         Add-Computer -DomainName {{ join_domain.domain_name }} -Credential $cred
-          -Force -ErrorAction Stop;
+          -Options JoinWithNewName,AccountCreate -Force -ErrorAction Stop;
     {%- endif -%}
         "changed=yes comment=`"Joined system to the domain.`"
         domain={{ join_domain.domain_name }}"


### PR DESCRIPTION
This patch will use a new, "pending" computer name when joining a
Windows system to an Active Directory domain. This allows a user
to rename a computer, then join a domain, and the new computer
name will be used for the computer account. Without this patch,
the old computer name would be used for the domain computer account.

This flag has been tested to work even if the computer name is not
changing.

See https://msdn.microsoft.com/en-us/library/windows/desktop/aa370433(v=vs.85).aspx.