### PR TITLE
Uses a run-once startup task to add local admins

### DIFF
--- a/join-domain/windows/files/Invoke-ScriptDeleteTask.ps1
+++ b/join-domain/windows/files/Invoke-ScriptDeleteTask.ps1
@@ -1,0 +1,71 @@
+[CmdLetBinding()]
+Param(
+    [Parameter(Mandatory=$false,Position=0,ValueFromRemainingArguments=$true)]
+    $RemainingArgs
+    ,
+    [Parameter(Mandatory=$True, ValueFromPipeline=$False)]
+    [String]
+    $Path
+    ,
+    [Parameter(Mandatory=$True)]
+    [String]
+    $TaskName
+)
+
+# Convert RemainingArgs to a hashtable
+$RemainingArgsHash = @{}
+If ($RemainingArgs)
+{
+    # PS2.0 receives remainingargs in a different format than PS3.0
+    If ($PSVersionTable.PSVersion -eq "2.0") {
+        $RemainingArgsHash = $RemainingArgs | ForEach-Object -Begin `
+        {
+            $index = 0
+            $hash = @{}
+        } -Process {
+            If ($index % 2 -eq 0) {
+                $hash[$_] = $RemainingArgs[$index+1]
+            }
+            $index++
+        } -End {
+            Write-Output $hash
+        }
+    }
+    Else
+    {
+        $RemainingArgsHash = $RemainingArgs | ForEach-Object -Begin `
+        {
+            $index = 0
+            $hash = @{}
+        } -Process {
+            If ($_ -match "^-.*$") {
+                $hash[($_.trim("-",":"))] = $RemainingArgs[$index+1]
+            }
+            $index++
+        } -End {
+            Write-Output $hash
+        }
+    }
+}
+Write-Debug "RemainingArgsHash = $((
+    $RemainingArgsHash.GetEnumerator() | % { `"-{0}: {1}`" -f $_.Key, $_.Value }
+) -join ' ')"
+
+# Run the script
+Write-Verbose "Running script ${Path}"
+Invoke-Expression "& ${Path} @RemainingArgsHash"
+
+# Delete the scheduled task
+$SchTasks = "${Env:SystemRoot}\system32\schtasks.exe"
+$SchArguments = @(
+    "/delete"
+    "/f"
+    "/TN"
+    "`"${TaskName}`""
+)
+
+Write-Verbose "Deleting scheduled task ${TaskName}"
+$null = Start-Process `
+    -FilePath ${SchTasks} `
+    -ArgumentList ${SchArguments} `
+    -NoNewWindow -PassThru -Wait

--- a/join-domain/windows/files/New-LocalGroupMember.ps1
+++ b/join-domain/windows/files/New-LocalGroupMember.ps1
@@ -1,0 +1,38 @@
+[CmdLetBinding()]
+Param(
+    [Parameter(Mandatory=$True, ValueFromPipeline=$True)]
+    [String[]]
+    $Members
+    ,
+    [Parameter(Mandatory=$True)]
+    [String]
+    $DomainNetBiosName
+    ,
+    [Parameter(Mandatory=$False)]
+    [String]
+    $Group = "Administrators"
+    )
+Begin
+{
+    $GroupObject = [ADSI]"WinNT://${Env:ComputerName}/${Group},group"
+    $GroupMembers = @(
+        @($GroupObject.Invoke("Members")) | ForEach {
+            $_.GetType().InvokeMember("Name", "GetProperty", $null, $_, $null)
+        }
+    )
+}
+Process
+{
+    ForEach ($Member in $Members)
+    {
+        If (!($Member -in $GroupMembers))
+        {
+            Write-Verbose "Adding ${Member} to group ${Group}"
+            $GroupObject.Add("WinNT://${DomainNetBiosName}/${Member},group")
+        }
+        Else
+        {
+            Write-Verbose "${Member} is already a member of group ${Group}"
+        }
+    }
+}

--- a/join-domain/windows/files/Register-RunOnceStartupTask.ps1
+++ b/join-domain/windows/files/Register-RunOnceStartupTask.ps1
@@ -1,0 +1,94 @@
+[CmdLetBinding()]
+Param(
+    [Parameter(Mandatory=$false,Position=0,ValueFromRemainingArguments=$true)]
+    $RemainingArgs
+    ,
+    [Parameter(Mandatory=$True, ValueFromPipeline=$False)]
+    [String]
+    $InvokeScript
+    ,
+    [Parameter(Mandatory=$True)]
+    [String]
+    $RunOnceScript
+)
+
+$TaskName = "RunOnceStartupTask-$([guid]::NewGuid())"
+
+$TaskPath = "${Env:SystemRoot}\System32\WindowsPowerShell\v1.0\powershell.exe"
+$PowerShellArgs = @(
+    "-NoProfile"
+    "-NonInteractive"
+    "-ExecutionPolicy"
+    "Bypass"
+    "-Command"
+)
+
+$WrapperArgs = @(
+    "`"${InvokeScript}`""
+    "-Path"
+    "`"${RunOnceScript}`""
+    "-TaskName"
+    "`"${TaskName}`""
+)
+
+$TaskArgs = ${PowerShellArgs} + ${WrapperArgs} + ${RemainingArgs}
+
+# Credit for the bulk of this structure:
+# https://ryanschlagel.wordpress.com/2012/07/09/managing-scheduled-tasks-with-powershell/
+Try
+{
+    [Object] $objScheduledTask = New-Object -ComObject("Schedule.Service")
+
+    If (!($objScheduledTask.Connected))
+    {
+        Try
+        {
+            $objScheduledTask.Connect()
+            $objScheduledTask_Folder = $objScheduledTask.GetFolder('\')
+            $objScheduledTask_TaskDefinition = $objScheduledTask.NewTask(0)
+
+            # Registration / Definitions
+            $objScheduledTask_RegistrationInfo = $objScheduledTask_TaskDefinition.RegistrationInfo
+
+            # Principal
+            $objScheduledTask_Principal = $objScheduledTask_TaskDefinition.Principal
+            $objScheduledTask_Principal.RunLevel = 1
+
+            # Define Settings
+            $objScheduledTask_Settings = $objScheduledTask_TaskDefinition.Settings
+            $objScheduledTask_Settings.Enabled = $True
+            $objScheduledTask_Settings.StartWhenAvailable = $True
+            $objScheduledTask_Settings.Hidden = $False
+
+            # Triggers
+            $objScheduledTask_Triggers = $objScheduledTask_TaskDefinition.Triggers
+            $objScheduledTask_Trigger = $objScheduledTask_Triggers.Create(8)
+            $objScheduledTask_Trigger.Enabled = $True
+
+            # Action
+            $objScheduledTask_Action = $objScheduledTask_TaskDefinition.Actions.Create(0)
+            $objScheduledTask_Action.Path = "${TaskPath}"
+            $objScheduledTask_Action.Arguments = "${TaskArgs}"
+
+            # Create Task
+            $objScheduledTask_Folder.RegisterTaskDefinition(
+                "${TaskName}",
+                $objScheduledTask_TaskDefinition,
+                6,
+                "SYSTEM",
+                $null,
+                5
+            ) | out-null
+            Write-Host "Scheduled Task Created Successfully" -ForegroundColor Green
+        }
+        Catch [System.Exception]
+        {
+            Write-Host "Scheduled Task Creation Failed" -ForegroundColor Red
+        }
+    }
+}
+Catch [System.Exception]
+{
+    Write-Host "Scheduled Task Creation Failed" -ForegroundColor Red
+    Write-Host "  EXCEPTION:" $_ -ForegroundColor Red
+}

--- a/join-domain/windows/map.jinja
+++ b/join-domain/windows/map.jinja
@@ -27,6 +27,18 @@
 
 {%- do join_domain.update(salt['grains.get']('join-domain', {})) %}
 
+{%- set wrapper = {
+    'name' : opts['cachedir'] ~ '\\extfiles\\join-domain\\Invoke-ScriptDeleteTask.ps1',
+    'source' : 'salt://' ~ tpldir ~ '/files/Invoke-ScriptDeleteTask.ps1'
+} %}
+
+{%- set new_member = {
+    'name' : opts['cachedir'] ~ '\\extfiles\\join-domain\\New-LocalGroupMember.ps1',
+    'source' : 'salt://' ~ tpldir ~ '/files/New-LocalGroupMember.ps1'
+} %}
+
 {%- do join_domain.update({
-    'admins' : admins
+    'admins' : admins,
+    'wrapper' : wrapper,
+    'new_member' : new_member
 }) %}


### PR DESCRIPTION
Adding local admins prior to this patch sometimes failed when the computer name had also changed, and when the system had just joined the domain but had not yet rebooted. The error message indicated that the trust relationship with the domain had failed. However, simply rebooting the system would repair the trust, and typically if the trust is broken then a reboot will not fix it. It is believed that some part of the authentication with the domain was continuing to use the old computer name, which caused the trust issues under the described circumstances.

This patch changes the mechanism for adding local admins, such that the members are added _after_ the system reboots. This is accomplished by registering a scheduled task that executes at system startup. The task runs a script that adds the domain members to the local administrators group, and then deletes the task.