### PR TITLE
Fixes Issue 72

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Set of parameters used for joining a AD-client to its domain:
     "/"-delimited path to the OU the computer account will be housed within.
 
 -   *`encrypted_password`*: This is an encrypted representation of the
-    `join_svc_acct` service account's password. Use `openssl`'s `aes-256-ecb`
+    `join_svc_acct` service account's password. Use `openssl`'s `aes-256-cbc`
     encryption option to create the encrypted-string.
 
 -   *`key`*: The string passed to `openssl` to encrypt/decrypt the
@@ -169,16 +169,17 @@ use `openssl`'s `enc` functionality to generate the reversible crypt-sting via
 a method similar to the following.
 
 ```bash
-echo "MyP@ssw*rd5tr1ng" | openssl enc -aes-256-ecb -a -e -salt -pass pass:"F_6ln9jV3X"
-U2FsdGVkX1/WgQtZRqlwwl67JQYHnsQce0dask0TuyqTnAXH8aGTfb/JLiOGUq4O
+$ echo "MyP@ssw*rd5tr1ng" | \
+   openssl enc -aes-256-cbc -md sha256 -a -e -salt -pass pass:"F_6ln9jV3X"
+U2FsdGVkX19pOx6FMnowkQ9vVGmHPuL5xWFwY5+EnB7Wy4rYze5HDmSZoTitwZDO
 ```
 
 After generating the crypt-string, verify its reversibility by doing something
 similar to the following:
 
 ```bash
-echo "U2FsdGVkX1/WgQtZRqlwwl67JQYHnsQce0dask0TuyqTnAXH8aGTfb/JLiOGUq4O" | \
-openssl enc -aes-256-ecb -a -d -salt -pass pass:"F_6ln9jV3X"
+echo "U2FsdGVkX19pOx6FMnowkQ9vVGmHPuL5xWFwY5+EnB7Wy4rYze5HDmSZoTitwZDO" | \
+   openssl enc -aes-256-cbc -md sha256 -a -d -salt -pass pass:"F_6ln9jV3X"
 MyP@ssw*rd5tr1ng
 ```
 

--- a/join-domain/elx/pbis/files/join.sh
+++ b/join-domain/elx/pbis/files/join.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -x
 #
 # Helper-script to more-intelligently handle joining PBIS client
 # to domain. Script replaces "PBIS-join" cmd.run method with
@@ -34,8 +35,8 @@ JOINSTAT=$(/opt/pbis/bin/pbis-status | \
 
 # Get clear-text password from crypt
 function PWdecrypt() {
-   local PWCLEAR=$(echo "${PWCRYPT}" | openssl enc -aes-256-ecb -a -d \
-                   -salt -pass pass:"${PWUNLOCK}")
+   local PWCLEAR=$(echo "${PWCRYPT}" | \
+                   openssl aes-256-cbc -md sha256 -a -d -k "${PWUNLOCK}")
 
    echo ${PWCLEAR}
 }
@@ -75,11 +76,11 @@ esac
 #########################
 
 # Make sure all were the parms were passed
-if [[ ${DOMSHORT} = "UNDEF" ]] || \
-   [[ ${DOMFQDN} = "UNDEF" ]] || \
-   [[ ${SVCACCT} = "UNDEF" ]] || \
-   [[ ${PWCRYPT} = "UNDEF" ]] || \
-   [[ ${PWUNLOCK} = "UNDEF" ]]
+if [[ ${DOMSHORT} = UNDEF ]] || \
+   [[ ${DOMFQDN} = UNDEF ]] || \
+   [[ ${SVCACCT} = UNDEF ]] || \
+   [[ ${PWCRYPT} = UNDEF ]] || \
+   [[ ${PWUNLOCK} = UNDEF ]]
 then
    printf "Usage: $0 <SHORT_DOMAIN> <DOMAIN_FQDN> <SVC_ACCT> "
    printf "<JOIN_PASS_CRYPT> <JOIN_PASS_UNLOCK>\n"


### PR DESCRIPTION
*Note:* when integrating with PBIS on EL7, it will be necessary to ensure that PBIS is version 8.5 or greater (tested with 8.5.2) - older versions have issues parsing the EL7 krb5.conf file.