### PR TITLE
Exits with stateful failure on a bad decryption

### DIFF
--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -52,10 +52,15 @@ NODENAME=$(hostname -s)
 
 # Decrypt Join Password
 function PWdecrypt() {
-   local PWCLEAR=$(echo "${PASSCRYPT}" | openssl enc -aes-256-cbc -md sha256 \
-                   -a -d -salt -pass pass:"${PASSULOCK}")
-
-   echo ${PWCLEAR}
+   local PWCLEAR
+   PWCLEAR=$(echo "${PASSCRYPT}" | openssl enc -aes-256-cbc -md sha256 -a -d \
+             -salt -pass pass:"${PASSULOCK}")
+   if [[ $? -ne 0 ]]
+   then
+     echo ""
+   else
+     echo "${PWCLEAR}"
+   fi
 }
 
 
@@ -132,10 +137,17 @@ function NukeCollision() {
 ######################
 PASSWORD=$(PWdecrypt)
 
+if [[ -z "${PASSWORD}" ]]
+then
+  printf "\n"
+  printf "changed=no comment='Failed to decrypt password'\n"
+  exit 1
+fi
+
 if [[ $(CheckObject) = NONE ]]
 then
    printf "\n"
-   printf "changed=no comment='No collisions for ${NODENAME} found"
+   printf "changed=no comment='No collisions for ${NODENAME} found "
    printf "in the directory'\n"
    exit 0
 elif [[ $(CheckMyJoinState) = "LOCALLYBOUND" ]]


### PR DESCRIPTION
Previously, the `PWdecrypt()` function was failing with a bad decrypt error, but was still returning bad data. The returned value wasn't being tested, so in fix-collisions.sh,  `CheckObject()` was still called. That function was also failing due to the bad password, in a way that caused `EXISTS` to be empty. `CheckObject()` then returned "NONE", which was matched as having no collisions, causing the script to report a stateful success. Salt would then continue to execute states that depended on fix-collisions.

This patch modifies `PWdecrypt()` to return an empty string if the decrypt fails. It then tests the return value and exits statefully with a failure if the returned value is empty. Salt then fails the dependent states without executing them.