### PR TITLE
Reworks elx pbis install and collision-test methods

### DIFF
--- a/join-domain/elx/pbis/config.sls
+++ b/join-domain/elx/pbis/config.sls
@@ -32,7 +32,7 @@ PBIS-config-Shell-{{ shell }}:
         fi
     - stateful: True
     - require:
-      - cmd: PBIS-installsh
+      - pkg: PBIS-install
 {%- endfor %}
 
 {%- for home in join_domain.pbis_user_home %}
@@ -52,7 +52,7 @@ PBIS-config-Home-{{ home }}:
         fi
     - stateful: True
     - require:
-      - cmd: PBIS-installsh
+      - pkg: PBIS-install
 {%- endfor %}
 
 PBIS-config-TrustIgnore:
@@ -71,7 +71,7 @@ PBIS-config-TrustIgnore:
         fi
     - stateful: True
     - require:
-      - cmd: PBIS-installsh
+      - pkg: PBIS-install
 
 PBIS-config-TrustList:
   cmd.run:
@@ -92,4 +92,4 @@ PBIS-config-TrustList:
         fi
     - stateful: True
     - require:
-      - cmd: PBIS-installsh
+      - pkg: PBIS-install

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -66,23 +66,7 @@ function PWdecrypt() {
 
 # Am I already joined
 function CheckMyJoinState() {
-   local CHKDOM=$(echo ${DOMAIN} | tr "[:lower:]" "[:upper:]")
-
-   # Try to accommodate back-to-back (ab)use cases
-   # This should ensure that the adcache file exists if the
-   # host is properly configured to talk to AD
-   HAVERPM=$(rpm -qa pbis-open pbis-enterprise)
-   if [[ "${HAVERPM}" != "" ]] &&
-      [[ ! -e /var/lib/pbis/krb5cc_lsass.${CHKDOM} ]]
-   then
-      service lwsmd restart > /dev/null 2>&1
-   fi
-
-   # See if adcache file exists - return value if it does
-   if [[ -e /var/lib/pbis/krb5cc_lsass.${CHKDOM} ]]
-   then
-      echo "LOCALLYBOUND"
-   fi
+   /opt/pbis/bin/lsa ad-get-machine account
 }
 
 
@@ -150,7 +134,7 @@ then
    printf "changed=no comment='No collisions for ${NODENAME} found "
    printf "in the directory'\n"
    exit 0
-elif [[ $(CheckMyJoinState) = "LOCALLYBOUND" ]]
+elif [[ -n "$(CheckMyJoinState)" ]]
 then
    printf "\n"
    printf "changed=no comment='Local system has active join config present "

--- a/join-domain/elx/pbis/files/join.sh
+++ b/join-domain/elx/pbis/files/join.sh
@@ -28,8 +28,6 @@ PWCRYPT=${4:-UNDEF}
 PWUNLOCK=${5:-UNDEF}
 JOINOU=${6:-UNDEF}
 JOINOU=${JOINOU// /\ }
-JOINSTAT=$(/opt/pbis/bin/pbis-status | \
-             awk '/^[ 	][ 	]*Status:/{print $2}')
 
 
 # Get clear-text password from crypt
@@ -43,6 +41,14 @@ function PWdecrypt() {
    else
      echo "${PWCLEAR}"
    fi
+}
+
+# Clear lsass service and get current join-status
+function JoinStatus() {
+   /opt/pbis/bin/lwsm restart lsass > /dev/null 2>&1
+   # Will take a few seconds for the status to refresh
+   sleep 3
+   /opt/pbis/bin/pbis-status | awk '/^[\t][\t]*Status:/{print $2}'
 }
 
 # Attempt to join client to domain
@@ -94,7 +100,7 @@ fi
 
 
 # Execute join-attempt as necessary...
-case ${JOINSTAT} in
+case $(JoinStatus) in
    Unknown)
       SVCPASS="$(PWdecrypt)"
       if [[ -z "${SVCPASS}" ]]

--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -11,23 +11,10 @@
 include:
   - .config
 
-PBIS-stageFile:
-  file.managed:
-    - name: '/var/tmp/{{ join_domain.package_name }}'
-    - source: '{{ join_domain.repo_uri_host }}/{{ join_domain.repo_uri_root_path }}/{{ join_domain.package_name }}'
-    - source_hash: '{{ join_domain.repo_uri_host }}/{{ join_domain.repo_uri_root_path }}/{{ join_domain.package_hash }}'
-    - user: root
-    - group: root
-    - mode: 0700
-
-PBIS-installsh:
-  cmd.script:
-    - name: 'install.sh /var/tmp/{{ join_domain.package_name }}'
-    - source: 'salt://{{ files }}/install.sh'
-    - cwd: '/root'
-    - stateful: True
-    - require:
-      - file: PBIS-stageFile
+PBIS-install:
+  pkg.installed:
+    - sources: {{ join_domain.connector_rpms }}
+    - allow_updates: True
 
 PBIS-NETBIOSfix:
   cmd.script:
@@ -36,7 +23,7 @@ PBIS-NETBIOSfix:
     - cwd: '/root'
     - stateful: True
     - require:
-      - cmd: PBIS-installsh
+      - pkg: PBIS-install
 
 PBIS-KillCollision:
   cmd.script:

--- a/join-domain/elx/pbis/map.jinja
+++ b/join-domain/elx/pbis/map.jinja
@@ -17,11 +17,9 @@ check_files:
   - lwi_events.db
   - lsass-adcache.filedb.{{ dns_name }}
 connector_rpms:
-  - pbis-open-legacy
-  - pbis-open
-  - pbis-open-devel
-  - pbis-open-gui
-  - pbis-open-upgrade
+  - pbis-open-legacy: https://s3.amazonaws.com/bits-public/beyond-trust/pbiso/pbis-open-8.5.3-293.x86_64.rpm
+  - pbis-open: https://s3.amazonaws.com/bits-public/beyond-trust/pbiso/pbis-open-legacy-8.5.3-293.x86_64.rpm
+  - pbis-open-upgrade: https://s3.amazonaws.com/bits-public/beyond-trust/pbiso/pbis-open-upgrade-8.5.3-293.x86_64.rpm
 pbis_user_home:
   - HomeDirTemplate
   - Local_HomeDirTemplate
@@ -42,6 +40,12 @@ login_shell: /bin/bash
     default = defaults,
     merge = True
 ) %}
+
+{%- do join_domain.update({
+    'connector_rpms': salt.pillar.get(
+        'join-domain:lookup:connector_rpms',
+        default = defaults.connector_rpms)
+}) %}
 
 {% do join_domain.update(
     salt.grains.get('join-domain', {})

--- a/pillar.example
+++ b/pillar.example
@@ -39,33 +39,24 @@ join-domain:
     #  - linux^operators
 
     # AD-connector Tool
-    #ad_connector: 'pbis'
+    #ad_connector: pbis
 
-    # Programable path-elements for retrieving the PBIS self-installing
-    # archive file.
-    #repo_uri_host: 'http://S3BUCKET.F.Q.D.N'
-    #repo_uri_root_path: 'beyond-trust/linux/pbis'
-
-    # Name of installer and hash-file to download
-    #package_name: 'pbis-open-8.3.0.3287.linux.x86_64.rpm.sh'
-    #package_hash: 'pbis-open-8.3.0.3287.linux.x86_64.rpm.sh.SHA512'
+    # List of RPM sources to install
+    #connector_rpms:
+    #  - pbis-open-legacy: https://s3.amazonaws.com/bits-public/beyond-trust/pbiso/pbis-open-legacy-8.5.3-293.x86_64.rpm
+    #  - pbis-open: https://s3.amazonaws.com/bits-public/beyond-trust/pbiso/pbis-open-8.5.3-293.x86_64.rpm
+    #  - pbis-open-devel: https://s3.amazonaws.com/bits-public/beyond-trust/pbiso/pbis-open-devel-8.5.3-293.x86_64.rpm
+    #  - pbis-open-gui: https://s3.amazonaws.com/bits-public/beyond-trust/pbiso/pbis-open-gui-8.5.3-293.x86_64.rpm
+    #  - pbis-open-upgrade: https://s3.amazonaws.com/bits-public/beyond-trust/pbiso/pbis-open-upgrade-8.5.3-293.x86_64.rpm
 
     # Directories where PBIS is installed to the system
-    #install_bin_dir: '/opt/pbis'
-    #install_var_dir: '/var/lib/pbis'
-    #install_db_dir: '/var/lib/pbis/db'
-
-    # List of RPMs to look for
-    #connector_rpms:
-    #  - 'pbis-open-legacy'
-    #  - 'pbis-open'
-    #  - 'pbis-open-devel'
-    #  - 'pbis-open-gui'
-    #  - 'pbis-open-upgrade'
+    #install_bin_dir: /opt/pbis
+    #install_var_dir: /var/lib/pbis
+    #install_db_dir: /var/lib/pbis/db
 
     # List of critical files to look for
     #check_files:
-    #  - 'registry.db'
-    #  - 'sam.db'
-    #  - 'lwi_events.db'
-    #  - 'lsass-adcache.filedb.FQDN'
+    #  - registry.db
+    #  - sam.db
+    #  - lwi_events.db
+    #  - lsass-adcache.filedb.FQDN


### PR DESCRIPTION
* Install method works directly with RPMs, rather than SHAR
* Collision-test uses same command as the pbis install script to check whether the system is already domain-joined