### PR TITLE
Disables nss enumeration if it is enabled

### DIFF
--- a/join-domain/elx/pbis/config.sls
+++ b/join-domain/elx/pbis/config.sls
@@ -93,3 +93,10 @@ PBIS-config-TrustList:
     - stateful: True
     - require:
       - pkg: PBIS-install
+
+PBIS-disable-NssEnumeration:
+  cmd.run:
+    - name: {{ join_domain.install_bin_dir }}/bin/config NssEnumerationEnabled false
+    - onlyif: test $({{ join_domain.install_bin_dir }}/bin/config --show NssEnumerationEnabled | grep -q -i "false")$? -ne 0
+    - require:
+      - pkg: PBIS-install


### PR DESCRIPTION
Disabling nss enumeration helps prevent lwsmd from locking up the
system when querying user info in a domain with a large number of
users and/or groups. Domain-based authentication still works fine.