### PR TITLE
Ignores invalid bad exit from pbis-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
         --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
         --name centos-${OS_VERSION} centos:${OS_VERSION} init
       sudo docker exec centos-${OS_VERSION} yum -y install \
-        https://repo.saltstack.com/yum/redhat/salt-repo-latest-1.el${OS_VERSION}.noarch.rpm
+        https://repo.saltstack.com/yum/redhat/salt-repo-latest-2.el${OS_VERSION}.noarch.rpm
       sudo docker exec centos-${OS_VERSION} yum -y install salt-minion util-linux-ng
       sudo docker exec centos-${OS_VERSION} salt-call --versions-report
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   global:
     SALT_FILEROOT: '%APPVEYOR_BUILD_FOLDER%'
     SALT_STATE: join-domain
-    SALT_URL: https://repo.saltstack.com/windows/Salt-Minion-2016.3.4-AMD64-Setup.exe
+    SALT_URL: https://repo.saltstack.com/windows/Salt-Minion-2016.11.5-AMD64-Setup.exe
   matrix:
     - SALT_PILLARROOT: '%APPVEYOR_BUILD_FOLDER%\tests\pillar\test-windows-main'
 

--- a/join-domain/elx/pbis/config.sls
+++ b/join-domain/elx/pbis/config.sls
@@ -96,7 +96,15 @@ PBIS-config-TrustList:
 
 PBIS-disable-NssEnumeration:
   cmd.run:
-    - name: {{ join_domain.install_bin_dir }}/bin/config NssEnumerationEnabled false
+    - name: '
+        {{ join_domain.install_bin_dir }}/bin/config NssEnumerationEnabled false > /dev/null 2>&1;
+        ret=$?;
+        if [[ $ret -eq 5 ]];
+        then
+            ret=0;
+        fi;
+        exit $ret;
+    '
     - onlyif: test $({{ join_domain.install_bin_dir }}/bin/config --show NssEnumerationEnabled | grep -q -i "false")$? -ne 0
     - require:
       - pkg: PBIS-install


### PR DESCRIPTION
The pbis config utility will return exit code 5 if the system
is not yet joined to the domain. The command still applies the
setting, so ignore this exit code.