### PR TITLE
Improves support of DnsSearchSuffix feature on ws2008r2 and ws2106

### DIFF
--- a/join-domain/windows/files/Set-DnsSearchSuffix.ps1
+++ b/join-domain/windows/files/Set-DnsSearchSuffix.ps1
@@ -11,10 +11,13 @@ param(
 if ($Ec2ConfigSetDnsSuffixList -ne "null")
 {
     $EC2SettingsFile = "${env:ProgramFiles}\Amazon\Ec2ConfigService\Settings\Config.xml"
-    $xml = [xml](get-content $EC2SettingsFile)
-    $xmlElement = $xml.get_DocumentElement()
-    $xmlElement.GlobalSettings.SetDnsSuffixList = "$Ec2ConfigSetDnsSuffixList".ToLower()
-    $xml.Save($EC2SettingsFile)
+    if (Test-Path $EC2SettingsFile)
+    {
+        $xml = [xml](get-content $EC2SettingsFile)
+        $xmlElement = $xml.get_DocumentElement()
+        $xmlElement.GlobalSettings.SetDnsSuffixList = "$Ec2ConfigSetDnsSuffixList".ToLower()
+        $xml.Save($EC2SettingsFile)
+    }
 }
 
 Set-DnsClientGlobalSetting -SuffixSearchList $DnsSearchSuffixes

--- a/join-domain/windows/files/Set-DnsSearchSuffix.ps1
+++ b/join-domain/windows/files/Set-DnsSearchSuffix.ps1
@@ -20,4 +20,11 @@ if ($Ec2ConfigSetDnsSuffixList -ne "null")
     }
 }
 
-Set-DnsClientGlobalSetting -SuffixSearchList $DnsSearchSuffixes
+if (Get-Command Set-DnsClientGlobalSetting -ErrorAction SilentlyContinue)
+{
+    Set-DnsClientGlobalSetting -SuffixSearchList $DnsSearchSuffixes
+}
+else
+{
+    Invoke-WmiMethod -Path Win32_NetworkAdapterConfiguration -Name SetDNSSuffixSearchOrder -ArgumentList $DnsSearchSuffixes
+}


### PR DESCRIPTION
Windows 2016 does not use the Ec2Config service, so the config.xml file is not present. It is not necessary to configure the equivalent SSM agent, since the SSM agent only sets the DNS search suffix at instance launch rather than every boot (as with the Ec2Config service). This patch tests for the file path before modifying it, meaning that on Windows 2016 this section is now just skipped.

Windows 2008 R2 comes with PowerShell 3.0, which does not include the commandlet `Set-DnsClientGlobalSetting`. This patch tests for the commandlet existence and if missing will fall back to the WMI method for setting the DNS search suffix.