### PR TITLE
Handle failures of adtool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,6 @@ matrix:
         - TESTENV=shellcheck
         - SHELLCHECK_OPTS="-s bash"
       id: 10
-      addons:
-##         apt:
-##           sources:
-##             - debian-sid    # Grab ShellCheck from the Debian repo
-##           packages:
-##             - shellcheck
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ matrix:
         - SHELLCHECK_OPTS="-s bash"
       id: 10
       addons:
-        apt:
-          sources:
-            - debian-sid    # Grab ShellCheck from the Debian repo
-          packages:
-            - shellcheck
+##         apt:
+##           sources:
+##             - debian-sid    # Grab ShellCheck from the Debian repo
+##           packages:
+##             - shellcheck
 
 before_install:
   - sudo apt-get update

--- a/join-domain/elx/files/ssh-allow-group.sh
+++ b/join-domain/elx/files/ssh-allow-group.sh
@@ -16,13 +16,13 @@ fi
 if [[ $(grep -q "AllowGroups.*${ALLOWGRP}" ${SSHCFG})$? -eq 0 ]]
 then
    printf "\n"
-   printf "changed=no comment='${ALLOWGRP} already present in sshd_config "
+   printf "changed=no comment='%s already present in sshd_config " "${ALLOWGRP}"
    printf "AllowGroups directive.'\n"
    exit 0
 else
-   sed -i 's/AllowGroups.*$/& '${ALLOWGRP}'/' ${SSHCFG}
+   sed -i "s/AllowGroups.*$/& ${ALLOWGRP}/" ${SSHCFG}
    printf "\n"
-   printf "changed=yes comment='Added ${ALLOWGRP} to AllowGroups "
+   printf "changed=yes comment='Added %s to AllowGroups " "${ALLOWGRP}"
    printf "directive in sshd_config.'\n"
    exit 0
 fi

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -136,8 +136,19 @@ function NukeCollision() {
 ######################
 ## Main program flow
 ######################
+# If already joined, no point proceeding further
+if [[ -n "$(CheckMyJoinState)" ]]
+then
+   printf "\n"
+   printf "changed=no comment='Local system has active join config present "
+   printf "in the directory'\n"
+   exit 0
+fi
+
+# Decrypt our password
 PASSWORD=$(PWdecrypt)
 
+# Bail if we can't decryption failed
 if [[ -z "${PASSWORD}" ]]
 then
   printf "\n"
@@ -145,18 +156,19 @@ then
   exit 1
 fi
 
+# See if we can find an collision, try to nuke if we do
 case $(CheckObject) in
-   NONE)
-      printf "\n"
-      printf "changed=no comment='No collisions for %s found " "${NODENAME}"
-      printf "in the directory'\n"
-      exit 0
-      ;;
    ERROR)
       OUTSTRING=$(<"${STATFILE}")
       printf "\n"
       printf "changed=no comment='Could not check for collision: "
       printf "%s.\n" "${OUTSTRING}"
+      exit 0
+      ;;
+   NONE)
+      printf "\n"
+      printf "changed=no comment='No collisions for %s found " "${NODENAME}"
+      printf "in the directory'\n"
       exit 0
       ;;
    *)

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -27,9 +27,6 @@
 #
 #################################################################
 PROGNAME="$( basename "${0}" )"
-STATFILE="/tmp/.${PROGNAME}.stat"
-trap "exit 0" TERM
-export TOP_PID=$$
 
 
 # Check if enoug args were passed

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -88,16 +88,16 @@ function CheckObject() {
    else
       if [[ ${EXISTS} =~ "ERROR: 400090" ]]
       then
-         printf "\n"
-         printf "changed=no comment='Could not check for collision: "
-         printf "authentication credentials not valid'\n"
-         kill -s TERM "${TOP_PID}"
+         OUTSTRING=$(
+            printf "changed=no comment='Could not check for collision: "
+            printf "authentication credentials not valid'\n"
+         )
       elif [[ ${EXISTS} =~ "ERROR:_500008" ]]
       then
-         printf "\n"
-         printf "changed=no comment='Could not check for collision: "
-         printf "Stronger authentication required'\n"
-         kill -s TERM "${TOP_PID}"
+         OUTSTRING=$(
+            printf "changed=no comment='Could not check for collision: "
+            printf "Stronger authentication required'\n"
+         )
       else
          echo "${EXISTS}"
       fi
@@ -153,6 +153,11 @@ then
    printf "\n"
    printf "changed=no comment='No collisions for %s found " "${NODENAME}"
    printf "in the directory'\n"
+   exit 0
+elif [[ ! -z ${OUTSTRING+x} ]]
+then
+   printf "\n"
+   echo "${OUTSTRING}"
    exit 0
 elif [[ -n "$(CheckMyJoinState)" ]]
 then

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # shellcheck disable=SC2155
 #
 # Under least-privileges security models, the PBIS installer can
@@ -27,6 +27,7 @@
 #
 #################################################################
 PROGNAME="$( basename "${0}" )"
+STATFILE="/tmp/.${PROGNAME}.stat"
 trap "exit 0" TERM
 export TOP_PID=$$
 
@@ -88,11 +89,11 @@ function CheckObject() {
    else
       if [[ ${EXISTS} =~ "ERROR: 400090" ]]
       then
-         OUTSTRING="authentication credentials not valid"
+         printf "authentication credentials not valid" > "${STATFILE}" || exit 1
          echo "ERROR"
       elif [[ ${EXISTS} =~ "ERROR:_500008" ]]
       then
-         OUTSTRING="Stronger authentication required"
+         printf "Stronger authentication required" > "${STATFILE}" || exit 1
          echo "ERROR"
       else
          echo "${EXISTS}"
@@ -152,6 +153,7 @@ case $(CheckObject) in
       exit 0
       ;;
    ERROR)
+      OUTSTRING=$(<"${STATFILE}")
       printf "\n"
       printf "changed=no comment='Could not check for collision: "
       printf "%s.\n" "${OUTSTRING}"

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -88,16 +88,12 @@ function CheckObject() {
    else
       if [[ ${EXISTS} =~ "ERROR: 400090" ]]
       then
-         OUTSTRING=$(
-            printf "changed=no comment='Could not check for collision: "
-            printf "authentication credentials not valid'\n"
-         )
+         OUTSTRING="authentication credentials not valid"
+         echo "ERROR"
       elif [[ ${EXISTS} =~ "ERROR:_500008" ]]
       then
-         OUTSTRING=$(
-            printf "changed=no comment='Could not check for collision: "
-            printf "Stronger authentication required'\n"
-         )
+         OUTSTRING="Stronger authentication required"
+         echo "ERROR"
       else
          echo "${EXISTS}"
       fi
@@ -148,23 +144,20 @@ then
   exit 1
 fi
 
-if [[ $(CheckObject) = NONE ]]
-then
-   printf "\n"
-   printf "changed=no comment='No collisions for %s found " "${NODENAME}"
-   printf "in the directory'\n"
-   exit 0
-elif [[ ! -z ${OUTSTRING+x} ]]
-then
-   printf "\n"
-   echo "${OUTSTRING}"
-   exit 0
-elif [[ -n "$(CheckMyJoinState)" ]]
-then
-   printf "\n"
-   printf "changed=no comment='Local system has active join config present "
-   printf "in the directory'\n"
-   exit 0
-else
-   NukeCollision
-fi
+case $(CheckObject) in
+   NONE)
+      printf "\n"
+      printf "changed=no comment='No collisions for %s found " "${NODENAME}"
+      printf "in the directory'\n"
+      exit 0
+      ;;
+   ERROR)
+      printf "\n"
+      printf "changed=no comment='Could not check for collision: "
+      printf "%s.\n" "${OUTSTRING}"
+      exit 0
+      ;;
+   *)
+      NukeCollision
+      ;;
+esac

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -91,7 +91,7 @@ function CheckObject() {
       then
          printf "authentication credentials not valid" > "${STATFILE}" || exit 1
          echo "ERROR"
-      elif [[ ${EXISTS} =~ "ERROR:_500008" ]]
+      elif [[ ${EXISTS} =~ "ERROR: 500008" ]]
       then
          printf "Stronger authentication required" > "${STATFILE}" || exit 1
          echo "ERROR"
@@ -162,7 +162,7 @@ case $(CheckObject) in
       OUTSTRING=$(<"${STATFILE}")
       printf "\n"
       printf "changed=no comment='Could not check for collision: "
-      printf "%s.\n" "${OUTSTRING}"
+      printf "%s'\n" "${OUTSTRING}"
       exit 0
       ;;
    NONE)

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -98,6 +98,7 @@ function CheckObject() {
       elif [[ ${EXISTS} =~ NERR_SetupNotJoined ]]
       then
          printf "Not setup/joined" > "${STATFILE}" || exit 1
+         echo "ERROR"
       else
          echo "${EXISTS}"
       fi

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -91,13 +91,13 @@ function CheckObject() {
          printf "\n"
          printf "changed=no comment='Could not check for collision: "
          printf "authentication credentials not valid'\n"
-         kill ${TOP_PID}
+         kill -s TERM "${TOP_PID}"
       elif [[ ${EXISTS} =~ "ERROR:_500008" ]]
       then
          printf "\n"
          printf "changed=no comment='Could not check for collision: "
          printf "Stronger authentication required'\n"
-         kill ${TOP_PID}
+         kill -s TERM "${TOP_PID}"
       else
          echo "${EXISTS}"
       fi

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -95,6 +95,9 @@ function CheckObject() {
       then
          printf "Stronger authentication required" > "${STATFILE}" || exit 1
          echo "ERROR"
+      elif [[ ${EXISTS} =~ NERR_SetupNotJoined ]]
+      then
+         printf "Not setup/joined" > "${STATFILE}" || exit 1
       else
          echo "${EXISTS}"
       fi

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -78,9 +78,9 @@ function CheckMyJoinState() {
 
 # Check for object-collisions
 function CheckObject() {
-   local EXISTS=$("${ADTOOL}" -d "${DOMAIN}" -n "${USERID}@${DOMAIN}" \
-                  -x "${PASSWORD}" -a search-computer \
-                  --name cn="${NODENAME}" -t 2>&1 )
+   local EXISTS=$( "${ADTOOL}" -d "${DOMAIN}" -n "${USERID}@${DOMAIN}" \
+                   -x "${PASSWORD}" -a search-computer \
+                   --name cn="${NODENAME}" -t 2>&1 | tr -d '\n' )
 
    if [[ -z ${EXISTS} ]]
    then

--- a/join-domain/elx/pbis/files/fix-hostname.sh
+++ b/join-domain/elx/pbis/files/fix-hostname.sh
@@ -43,12 +43,12 @@ then
    else
       OLDFQDN=$(hostname)
       CURDOM=$(awk -F = '/HOSTNAME/{print $2}' /etc/sysconfig/network | \
-               sed 's/'$(hostname -s)'\.//')
+               sed "s/$(hostname -s)\.//")
       BASEIP=$(printf '%02X' \
-               $(ip addr show ${DEFIF} | \
+               "$(ip addr show "${DEFIF}" | \
                  awk '/inet /{print $2}' | \
                  sed -e 's#/.*$##' -e 's/\./ /g' \
-               ))
+               )")
 
       # Try to make new hostname fully-qualified
       if [[ ${CURDOM} = "" ]]
@@ -58,19 +58,20 @@ then
          NEWFQDN="ip-${BASEIP,,}.${CURDOM}"
       fi
 
-      if [[ $(hostname ${NEWFQDN})$? -eq 0 ]]
+      if [[ $(hostname "${NEWFQDN}" )$? -eq 0 ]]
       then
          # Create info-preservation files
-         echo ${OLDFQDN} > /etc/sysconfig/hostname.fqdn-orig
-         echo ${NEWFQDN} > /etc/sysconfig/hostname.fqdn-new
+         echo "${OLDFQDN}" > /etc/sysconfig/hostname.fqdn-orig
+         echo "${NEWFQDN}" > /etc/sysconfig/hostname.fqdn-new
 
          printf "\n"
-         printf "changed=yes comment='Changed hostname from ${OLDFQDN} to ${NEWFQDN}.'\n"
+         printf "changed=yes comment='Changed hostname from %s to " "${OLDFQDN}"
+         printf "%s.'\n" "${NEWFQDN}"
          exit 0
       else
          printf "\n"
          printf "changed=no comment='Failed to change hostname "
-         printf "to ${NEWFQDN}.'\n"
+         printf "to %s.'\n" "${NEWFQDN}
          exit 1
       fi
    fi

--- a/join-domain/elx/pbis/files/fix-hostname.sh
+++ b/join-domain/elx/pbis/files/fix-hostname.sh
@@ -71,7 +71,7 @@ then
       else
          printf "\n"
          printf "changed=no comment='Failed to change hostname "
-         printf "to %s.'\n" "${NEWFQDN}
+         printf "to %s.'\n" "${NEWFQDN}"
          exit 1
       fi
    fi

--- a/join-domain/elx/pbis/files/fix-pam.sh
+++ b/join-domain/elx/pbis/files/fix-pam.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2155
 #
 # This script is designed to fix PAM stack-order munging that may
 # be caused by the PBIS package's "join" operations. When the
@@ -22,11 +23,11 @@ function FindRealFile() {
 # Fix munged stack-ordering
 function FixPam() {
    local MOVELSASS=$(grep -q -E \
-                     '^auth[ 	][ 	]*.*pam_lsass.so' ${CHKFILE})$?
+                     '^auth[ 	][ 	]*.*pam_lsass.so' "${CHKFILE}")$?
 
    if [[  ${MOVELSASS} -eq 0 ]]
    then
-      local NUKIT=$(sed -i '/^auth[ 	][ 	]*.*pam_lsass.so/d' ${CHKFILE})$?
+      local NUKIT=$(sed -i '/^auth[ 	][ 	]*.*pam_lsass.so/d' "${CHKFILE}")$?
       if [[ ${NUKIT} -ne 0 ]]
       then
          printf "\n"
@@ -39,7 +40,7 @@ function FixPam() {
       ITXT2="auth        sufficient      pam_lsass.so      try_first_pass"
 
       sed -i '/^auth.*default=die.*faillock/s/^/'"${ITXT1}"'\n'"${ITXT2}"'\n/' \
-         ${CHKFILE}
+         "${CHKFILE}"
 
       printf "\n"
       printf "changed=yes comment='Moved pam_lsass modules up-stack.'\n"
@@ -61,7 +62,7 @@ function FixPam() {
 
 # Resolve sym-links
 CHKFILE=$(FindRealFile "${PAMFILE}")
-CKFAILLOCK=$(grep -q -E "^auth[ 	][ 	]*.*pam_faillock" ${CHKFILE})$?
+CKFAILLOCK=$(grep -q -E "^auth[ 	][ 	]*.*pam_faillock" "${CHKFILE}")$?
 
 # Only act if pam_faillock is in play
 if [[ ${CKFAILLOCK} -eq 0 ]]
@@ -70,5 +71,5 @@ then
 else
    printf "\n"
    printf "changed=no comment='The faillock PAM module not present: "
-   printf "leaving ${CHKFILE} as-is'"
+   printf "leaving %s as-is'" "${CHKFILE}"
 fi

--- a/join-domain/elx/pbis/files/install.sh
+++ b/join-domain/elx/pbis/files/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+# shellcheck disable=SC2181
 #
 # Salt state for downloading, installing and configuring PBIS,
 # then joining # the instance to Active Directory
@@ -12,7 +12,7 @@ ISINSTALLED=$(echo "${PBISPKG}" | grep -- "-${INSTPBISVERS}.")
 
 if [[ "${INSTPBISVERS}" = "" ]] || [[ "${ISINSTALLED}" = "" ]]
 then
-   bash ${PBISPKG} -- --dont-join --legacy install > /dev/null 2>&1
+   bash "${PBISPKG}" -- --dont-join --legacy install > /dev/null 2>&1
    if [[ $? -eq 0 ]]
    then
       # There's a slight delay between binaries' install and
@@ -21,16 +21,16 @@ then
       sleep 5
 
       printf "\n"
-      printf "changed=yes comment='Installed RPMs from ${PBISPKG}.'\n"
+      printf "changed=yes comment='Installed RPMs from %s.'\n" "${PBISPKG}"
       exit 0
    else
       printf "\n"
-      printf "changed=no comment='Installer ${PBISPKG} did not run "
+      printf "changed=no comment='Installer %s did not run " "${PBISPKG}"
       printf "as expected.'\n"
       exit 1
    fi
 else
    printf "\n"
-   printf "changed=no comment='RPMs from ${PBISPKG} already present.'\n"
+   printf "changed=no comment='RPMs from %s already present.'\n" "${PBISPKG}"
    exit 0
 fi

--- a/join-domain/elx/pbis/files/join.sh
+++ b/join-domain/elx/pbis/files/join.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2181
 #
 # Helper-script to more-intelligently handle joining PBIS client
 # to domain. Script replaces "PBIS-join" cmd.run method with
@@ -57,12 +58,12 @@ function DomainJoin() {
    case "${JOINOU}" in
       none|None|NONE|UNDEF)
          domainjoin-cli join --assumeDefaultDomain \
-           yes --userDomainPrefix ${DOMSHORT} ${DOMFQDN} \
+           yes --userDomainPrefix "${DOMSHORT}" "${DOMFQDN}" \
            "${SVCACCT}" "${SVCPASS}" # > /dev/null 2>&1
          ;;
       *)
          domainjoin-cli join --ou "${JOINOU}" --assumeDefaultDomain \
-           yes --userDomainPrefix ${DOMSHORT} ${DOMFQDN} \
+           yes --userDomainPrefix "${DOMSHORT}" "${DOMFQDN}" \
            "${SVCACCT}" "${SVCPASS}" # > /dev/null 2>&1
          ;;
 esac
@@ -70,12 +71,12 @@ esac
    if [[ $? -eq 0 ]]
    then
       printf "\n"
-      printf "changed=yes comment='Joined client to domain ${DOMSHORT}.'\n"
+      printf "changed=yes comment='Joined client to domain %s.'\n" "${DOMSHORT}"
       exit 0
    else
       printf "\n"
       printf "changed=no comment='Failed to join client to domain "
-      printf "${DOMSHORT}.'\n"
+      printf "%s.'\n" "${DOMSHORT}"
       exit 1
    fi
 }
@@ -92,7 +93,7 @@ if [[ ${DOMSHORT} = UNDEF ]] || \
    [[ ${PWCRYPT} = UNDEF ]] || \
    [[ ${PWUNLOCK} = UNDEF ]]
 then
-   printf "Usage: $0 <SHORT_DOMAIN> <DOMAIN_FQDN> <SVC_ACCT> "
+   printf "Usage: %s <SHORT_DOMAIN> <DOMAIN_FQDN> <SVC_ACCT> " "${0}"
    printf "<JOIN_PASS_CRYPT> <JOIN_PASS_UNLOCK>\n"
    echo "Failed to pass a required parameter. Aborting."
    exit 1


### PR DESCRIPTION
Previously, if the query using `adtool` wholly failed (i.e., exited non-zero), the `fix-collision.sh` script would go about its merry way and attempt the nuke-action, any way. In some use-cases, if the `adtool`-based query exits non-zero, the nuke-action would also fail with a non-zero exit, causing subsequent actions (like the domain-join operation) to be wholly skipped. This modification should allow a domain-join to be attempted even if `adtool` is unusable (bug in PBIS version; incompatibility with domain security-settings, etc.)

closes #106 

** NOTE: Version of `adtool` in PBIS 8.5.3-293 is highly-broken (LDAP auth non-functional in many use-cases) : the `adtool` query-logic was failing but not being caught (due to missing error-logic). Will want to upgrade deployed PBIS version to something where `adtool` is actually semi-functional.