### PR TITLE
Conditionally-invoke PBIS's update-dns Utility

### DIFF
--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -66,7 +66,6 @@ PBIS-PamSystemDemunge:
 PBIS-DDNS:
   cmd.run:
     - name: {{ join_domain.install_bin_dir }}/bin/update-dns
-    '
     - require:
       - cmd: PBIS-join
 {%- endif %}

--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -65,7 +65,7 @@ PBIS-PamSystemDemunge:
 {%- if usePbisDdns %}
 PBIS-DDNS:
   cmd.run:
-    - name: '
+    - name: {{ join_domain.install_bin_dir }}/bin/update-dns
         {{ join_domain.install_bin_dir }}/bin/update-dns;
         ret=$?;
         exit $ret;

--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -7,7 +7,7 @@
 
 {#- Set location for helper-files #}
 {%- set files = tpldir ~ '/files' %}
-{%- set usePbisDdns = salt.pillar.get('ash-linux:lookup:pbis-dns', []) %}
+{%- set usePbisDdns = salt.pillar.get('join-domain:lookup:pbis-ddns') %}
 
 include:
   - .config
@@ -62,16 +62,12 @@ PBIS-PamSystemDemunge:
     - require:
       - cmd: PBIS-join
 
-{%- if usePbisDdns = true %}
+{%- if usePbisDdns %}
 PBIS-DDNS:
-  cmd.script:
+  cmd.run:
     - name: '
-        {{ join_domain.install_bin_dir }}/bin/update-dns ;
+        {{ join_domain.install_bin_dir }}/bin/update-dns;
         ret=$?;
-        if [[ $ret -eq 5 ]];
-        then
-            ret=0;
-        fi;
         exit $ret;
     '
     - require:

--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -7,6 +7,7 @@
 
 {#- Set location for helper-files #}
 {%- set files = tpldir ~ '/files' %}
+{%- set usePbisDdns = salt.pillar.get('ash-linux:lookup:pbis-dns', []) %}
 
 include:
   - .config
@@ -60,3 +61,19 @@ PBIS-PamSystemDemunge:
     - stateful: True
     - require:
       - cmd: PBIS-join
+
+{%- if usePbisDdns = true %}
+PBIS-DDNS:
+  cmd.script:
+    - name: '
+        {{ join_domain.install_bin_dir }}/bin/update-dns ;
+        ret=$?;
+        if [[ $ret -eq 5 ]];
+        then
+            ret=0;
+        fi;
+        exit $ret;
+    '
+    - require:
+      - cmd: PBIS-join
+{%- endif %}

--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -66,7 +66,6 @@ PBIS-PamSystemDemunge:
 PBIS-DDNS:
   cmd.run:
     - name: {{ join_domain.install_bin_dir }}/bin/update-dns
-        {{ join_domain.install_bin_dir }}/bin/update-dns;
         ret=$?;
         exit $ret;
     '

--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -7,7 +7,7 @@
 
 {#- Set location for helper-files #}
 {%- set files = tpldir ~ '/files' %}
-{%- set usePbisDdns = salt.pillar.get('join-domain:lookup:pbis-ddns') %}
+{%- set usePbisDdns = salt.pillar.get('join-domain:lookup:update-dns') %}
 
 include:
   - .config

--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -66,7 +66,6 @@ PBIS-PamSystemDemunge:
 PBIS-DDNS:
   cmd.run:
     - name: {{ join_domain.install_bin_dir }}/bin/update-dns
-        ret=$?;
         exit $ret;
     '
     - require:

--- a/join-domain/elx/pbis/init.sls
+++ b/join-domain/elx/pbis/init.sls
@@ -66,7 +66,6 @@ PBIS-PamSystemDemunge:
 PBIS-DDNS:
   cmd.run:
     - name: {{ join_domain.install_bin_dir }}/bin/update-dns
-        exit $ret;
     '
     - require:
       - cmd: PBIS-join

--- a/pillar.example
+++ b/pillar.example
@@ -67,7 +67,8 @@ join-domain:
     #  - lwi_events.db
     #  - lsass-adcache.filedb.FQDN
 
-    # Whether to try to use PBIS's `update-dns` utility to send a DDNS update request.
+    # Whether to try to use AD-integration subsystem's associated utility for
+    # issuing a DDNS update request.
     #    Note: this is only known to work with DNS systems based on Microsoft's
     #          DNS-integrated Active Directory service.
-    #pbis-ddns: true
+    #update-dns: true

--- a/pillar.example
+++ b/pillar.example
@@ -66,3 +66,8 @@ join-domain:
     #  - sam.db
     #  - lwi_events.db
     #  - lsass-adcache.filedb.FQDN
+
+    # Whether to try to use PBIS's `update-dns` utility to send a DDNS update request.
+    #    Note: this is only known to work with DNS systems based on Microsoft's
+    #          DNS-integrated Active Directory service.
+    #pbis-ddns: true


### PR DESCRIPTION
Extended the `pbis` init-file's contents to check pillar for a `pbis-ddns` flag (update `pillar.example`, too). If present and the value is `true`, the Linux join-domain formula will invoke the PBIS `udate-dns` utility to attempt a DDNS update. 

Unfortunately, lab DNS is not compatible. I will need to test this in the production dev account. I know the utility works there. However, I need to verify whether the fact that it gets a positive return on the A-record update but a negative return on the PTR-record update causes a non-zero exit state.

Closes #111 