### PR TITLE
Issue 116

### DIFF
--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -130,14 +130,18 @@ function FindDCs {
 function FindComputer {
    local COMPUTERNAME
    local SEARCHEXIT
+   local SEARCHTERM
+
+   SEARCHTERM="(&(objectCategory=computer)(|(cn=${HOSTNAME})(cn=${HOSTNAME^^})(cn=${HOSTNAME,,})))"
 
    # Searach without STARTLS
    COMPUTERNAME=$( ldapsearch -LLL -x -h "${DCINFO//*;/}" -p "${DCINFO//;*/}" \
-         -D "${QUERYUSER}" -w "${BINDPASS}" -b "${SEARCHSCOPE}" -s sub \
-         cn="${HOSTNAME}" cn 2> /dev/null || \
+        -D "${QUERYUSER}" -w "${BINDPASS}" -b "${SEARCHSCOPE}" -s sub \
+        "${SEARCHTERM}" cn 2> /dev/null || \
       ldapsearch -LLL -Z -x -h "${DCINFO//*;/}" -p \
-         "${DCINFO//;*/}" -D "${QUERYUSER}" -w "${BINDPASS}" \
-         -b "${SEARCHSCOPE}" -s sub cn="${HOSTNAME}" cn 2> /dev/null 
+        "${DCINFO//;*/}" -D "${QUERYUSER}" -w "${BINDPASS}" \
+        -b "${SEARCHSCOPE}" -s sub \
+        "${SEARCHTERM}" cn 2> /dev/null
    )
 
    COMPUTERNAME=$( echo "${COMPUTERNAME}" | awk '/^dn:/{ print $2 }' )

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -100,7 +100,7 @@ function FindDCs {
 
    DNS_SEARCH_STRING="_ldap._tcp.dc._msdcs.${1}"
    IDX=0
-   SEARCH_LIST=($( dig -t SRV "${DNS_SEARCH_STRING}" | awk '/ IN SRV /{ printf("%s;%s\n",$7,$8)}' ))
+   SEARCH_LIST=($( dig -t SRV "${DNS_SEARCH_STRING}" | awk '/\sIN SRV\s/{ printf("%s;%s\n",$7,$8)}' ))
 
    # Parse list of domain-controllers to see who we can connect to
    for DC in "${SEARCH_LIST[@]}"


### PR DESCRIPTION
Closes #116 

Opted to use a compound-query:

~~~
(&(objectCategory=computer)(|(cn=${HOSTNAME})(cn=${HOSTNAME^^})(cn=${HOSTNAME,,})))
~~~

To match any computer object whose name case-matched the passed-value of HOSTNAME, the fully upper-cased version of the passed-value of HOSTNAME and the fully lower-cased version of the passed-value of HOSTNAME. While it _should_ never happen, adding `objectCategory=computer` to the compound query should ensure that any other object-types that happen to match the searched for string are ignored.

Also: some DNS-based searches for the AD server name will have the `IN SRV` record padded with tabs, while some will be padded with spaces. Updated match-criteria to use generic whitespace token (i.e., `\s`)