### PR TITLE
Issue 118

### DIFF
--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -87,7 +87,12 @@ function PWdecrypt() {
 
 # Am I already joined
 function CheckMyJoinState() {
-   /opt/pbis/bin/lsa ad-get-machine account
+   /opt/pbis/bin/lsa ad-get-machine account > /dev/null 2>&1
+
+   if [[ $? -eq 0 ]]
+   then
+      echo "IS_JOINED"
+   fi
 }
 
 
@@ -161,7 +166,7 @@ function NukeCollision() {
 ## Main program flow
 ######################
 # If already joined, no point proceeding further
-if [[ -n "$(CheckMyJoinState)" ]]
+if [[ $(CheckMyJoinState) == IS_JOINED ]]
 then
    printf "\n"
    printf "changed=no comment='Local system has active join config present "

--- a/join-domain/elx/pbis/files/fix-collisions.sh
+++ b/join-domain/elx/pbis/files/fix-collisions.sh
@@ -102,7 +102,7 @@ function CheckObject() {
    local EXISTS=$( "${ADTOOL}" -d "${DOMAIN}" -n "${USERID}@${DOMAIN}" \
                    -x "${PASSWORD}" -a search-computer \
                    --name cn="${NODENAME}" -t 2>&1 | tr -d '\n' )
-   ADTOOLERR=$( ${EXISTS// /_} | sed -e 's/(//g' -e 's/)//g' )
+   ADTOOLERR=$( echo ${EXISTS// /_} | sed -e 's/(//g' -e 's/)//g' )
 
    if [[ -z ${EXISTS} ]]
    then


### PR DESCRIPTION
Turned out there was a missing `echo` from the `ADTOOLERR=$( … )` [line](https://github.com/plus3it/join-domain-formula/blob/master/join-domain/elx/pbis/files/fix-collisions.sh#L100). This was causing a null-string to be passed to the err-string [evaluation-block](https://github.com/ferricoxide/join-domain-formula/blob/69ab37962f98b92272dc55a50259ea4e87862c4d/join-domain/elx/pbis/files/fix-collisions.sh#L113-L129).

Also: the logic for determining "this host lacks standing to query the domain - exit _now_" was borked. Addressed in f132f7c.