### PR TITLE
Ensure vars are properly initialized

### DIFF
--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -105,9 +105,11 @@ function PWdecrypt {
 function FindDCs {
    local DNS_SEARCH_STRING
    local IDX
+   local DC
    local SEARCH_LIST
 
    DNS_SEARCH_STRING="_ldap._tcp.dc._msdcs.${1}"
+   DC=()
    IDX=0
    SEARCH_LIST=($( dig -t SRV "${DNS_SEARCH_STRING}" | awk '/\sIN SRV\s/{ printf("%s;%s\n",$7,$8)}' ))
 


### PR DESCRIPTION
Some vars that never get referenced in the test environment get triggered in one of the prod environments ...pissing off strict-mode. This fixes the ones that got activated today.