### PR TITLE
Add support for Active Directory Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,17 @@ See the [pillar.example](pillar.example) file for pillar-data structuring.
 
 Set of parameters used for joining a AD-client to its domain:
 
--   *`ad_domain_fqdn`*: The fully-qualified DNS name for the AD domain (e.g.,
+-   *`dns_name`*: The fully-qualified DNS name for the AD domain (e.g.,
     'aws.lab')
 
--   *`ad_domain_short`*: The "short" or NETBIOS name for the AD domain (e.g.,
+-   *`ad_site_name`*: (OPTIONAL) The logical name of an Active Directory Sites
+    and Services [site](https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/plan/site-functions)
+    to query for domain-controllers.
+
+-   *`netbios_name`*: The "short" or NETBIOS name for the AD domain (e.g.,
     'AWSLAB')
 
--   *`join_svc_acct`*: The account name used to perform automated joins of
+-   *`username`*: The account name used to perform automated joins of
     clients to the AD domain (e.g., 'svc_domjoin_aws'). It is recommended to
     create a service account that has the bare-minimum permissions necessary to
     (re)join a client to an AD domain.
@@ -101,24 +105,31 @@ Set of parameters used for joining a AD-client to its domain:
 -   *`key`*: The string passed to `openssl` to encrypt/decrypt the
     `join_svc_acct` service account's password.
 
+### Information used configure domain-joined client's behvior
+
+-   *`admin_users`*: (OPTIONAL) List of users to add to the sudoers system
+-   *`admin_groups`*: (OPTIONAL) List of groups to add to the sudoers system
+-   *`login_users`*: (OPTIONAL) List of users to add to SSH daemon's `AllowUsers`
+    list.  Note: all `admin_users` are automatically included in this list.
+-   *`login_groups`*: (OPTIONAL) List of groups to add to SSH daemon's
+    `AllowGroups` list. Note: (OPTIONAL)all `admin_groups` are automatically
+    included in this list.
+-   *`trusted_domains`*: (OPTIONAL) List of domains (within a multi-domin
+    forest) to trust
+
 ### Settings for the URI path-elements to the PBIS installer
 
 These two values are used to determine where to locate the AD-client's
 installer software. HTTP is the expected (read "tested") download method. Other
 download methods may also work (but have not been tested).
 
--   *`repo_uri_host`*: '<http://S3BUCKET.F.Q.D.N>'
--   *`repo_uri_root_path`*: 'beyond-trust/linux/pbis'
-
-### Name of installer and hash-file to download
-
-Name of the installation package to download from the repo. The installer
-staging-routines expect the downloaded file to have a signature file. The
-signature file is used to ensure that the package download was not corrupted
-in transit.
-
--   *`package_name`*: 'pbis-open-8.3.0.3287.linux.x86_64.rpm.sh'
--   *`package_hash`*: 'pbis-open-8.3.0.3287.linux.x86_64.rpm.sh.SHA512'
+-   *`connector_rpms`*: Top-level search-key for PBIS-related elements.
+    Remaining keys in this block are sub-keys of this key.
+-   *`pbis-open`*: URL of the `pbis-open` RPM
+-   *`pbis-open-devel`*: URL of the `pbis-open-devel` RPM (rarely used)
+-   *`pbis-open-gui`*: URL of the `pbis-open-gui` RPM (rarely used)
+-   *`pbis-open-legacy`*: URL of the `pbis-open-legacy` RPM (infrequently used)
+-   *`pbis-open-upgrade`*: URL of the `pbis-open-upgrade` RPM
 
 ### Tool used for joining client to AD domain
 

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -73,6 +73,7 @@ function UsageMsg {
 
       echo "Usage: ${0} [GNU long option] [option] ..."
       echo "  Options:"
+      printf "\t-a <AD_SITENAME> \n"
       printf "\t-c <ENCRYPTED_PASSWORD>  \n"
       printf "\t-d <LONG_DOMAIN_NAME>  \n"
       printf "\t-f <FORCED_HOSTNAME>  \n"
@@ -90,6 +91,7 @@ function UsageMsg {
       printf "\t--join-user <DIRECTORY_USER> \n"
       printf "\t--ldap-host <LDAP_QUERY_HOST>  \n"
       printf "\t--ldap-type <LDAP_TYPE> \n"
+      printf "\t--ad-site <AD_SITENAME> \n"
    ) >&2
    exit 1
 }
@@ -243,8 +245,8 @@ then
    logIt "No arguments given. Aborting" 1
 fi
 
-# Define flags to look for..
-OPTIONBUFR=$(getopt -o c:d:f:hk:l:p:u:t: --long domain-name:,help,hostname:,join-user:,join-crypt:,join-key:,join-password:,ldap-host:,ldap-type:,mode: -n "${PROGNAME}" -- "$@")
+# Define flags to look for...
+OPTIONBUFR=$(getopt -o c:d:f:hk:l:p:s:t:u: --long domain-name:,help,hostname:,join-crypt:,join-key:,join-password:,join-user:,ldap-host:,ldap-type:,mode:ad-site: -n "${PROGNAME}" -- "$@")
 
 # Check for mutually-exclusive arguments
 if [[ ${OPTIONBUFR} =~ p\ |join-password && ${OPTIONBUFR} =~ c\ |join-crypt ]] ||
@@ -366,6 +368,19 @@ do
                ;;
             *)
                BINDPASS="${2}"
+               shift 2;
+               ;;
+         esac
+         ;;
+      -s|--ad-site)
+         case "$2" in
+            "")
+               logIt "Error: option required but not specified" 1
+               shift 2;
+               exit 1
+               ;;
+            *)
+               ADSITE="${2}"
                shift 2;
                ;;
          esac

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# shellcheck disable=
+# shellcheck disable=SC2236,SC2207
 #
 # set -euo pipefail
 #

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -141,12 +141,16 @@ function FindDCs {
    local IDX
    local DC
 
+   # Select whether to try to use AD 
    if [[ ! -z ${ADSITE} ]]
    then
-      DNS_SEARCH_STRING="_ldap._tcp.${ADSITE}.sites.dc._msdcs.${1}"
+      DNS_SEARCH_STRING="_ldap._tcp.${ADSITE}._sites.dc._msdcs.${1}"
    else
       DNS_SEARCH_STRING="_ldap._tcp.dc._msdcs.${1}"
    fi
+
+   export DNS_SEARCH_STRING
+    
    IDX=0
    DC=($( 
          dig -t SRV "${DNS_SEARCH_STRING}" | \
@@ -251,7 +255,7 @@ then
 fi
 
 # Define flags to look for...
-OPTIONBUFR=$(getopt -o c:d:f:hk:l:p:s:t:u: --long domain-name:,help,hostname:,join-crypt:,join-key:,join-password:,join-user:,ldap-host:,ldap-type:,mode:ad-site: -n "${PROGNAME}" -- "$@")
+OPTIONBUFR=$(getopt -o c:d:f:hk:l:p:s:t:u: --long domain-name:,help,hostname:,join-crypt:,join-key:,join-password:,join-user:,ldap-host:,ldap-type:,mode:,ad-site: -n "${PROGNAME}" -- "$@")
 
 # Check for mutually-exclusive arguments
 if [[ ${OPTIONBUFR} =~ p\ |join-password && ${OPTIONBUFR} =~ c\ |join-crypt ]] ||

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -141,7 +141,12 @@ function FindDCs {
    local IDX
    local DC
 
-   DNS_SEARCH_STRING="_ldap._tcp.dc._msdcs.${1}"
+   if [[ ! -z ${ADSITE} ]]
+   then
+      DNS_SEARCH_STRING="_ldap._tcp.${ADSITE}.sites.dc._msdcs.${1}"
+   else
+      DNS_SEARCH_STRING="_ldap._tcp.dc._msdcs.${1}"
+   fi
    IDX=0
    DC=($( 
          dig -t SRV "${DNS_SEARCH_STRING}" | \

--- a/join-domain/elx/openldap-client/find-collision.sls
+++ b/join-domain/elx/openldap-client/find-collision.sls
@@ -19,7 +19,11 @@ RPM-installs:
 LDAP-FindCollison:
   cmd.script:
     - cwd: '/root'
+{%- if join_domain.ad_site_name %}
+    - name: 'find-collisions.sh -d "{{ join_domain.dns_name }}" -s "{{ join_domain.ad_site_name }}" -u "{{ join_domain.username }}" -c "{{ join_domain.encrypted_password }}" -k "{{ join_domain.key }}" --mode saltstack'
+{%- else %}
     - name: 'find-collisions.sh -d "{{ join_domain.dns_name }}" -u "{{ join_domain.username }}" -c "{{ join_domain.encrypted_password }}" -k "{{ join_domain.key }}" --mode saltstack'
+{%- endif %}
     - require:
       - pkg: RPM-installs
     - source: 'salt://{{ files }}/find-collisions.sh'

--- a/join-domain/elx/openldap-client/map.jinja
+++ b/join-domain/elx/openldap-client/map.jinja
@@ -4,6 +4,12 @@
     salt.pillar.get('join-domain:lookup:dns_name')
 ) %}
 
+{#- Grab the ad_site_name to use it in the defaults #}
+{%- set ad_site_name = salt.grains.get(
+    'join-domain:ad_site_name',
+    salt.pillar.get('join-domain:lookup:ad_site_name')
+) %}
+
 {#- Set join-domain defaults for this ad connector #}
 {%- load_yaml as defaults %}
 

--- a/join-domain/elx/openldap-client/map.jinja
+++ b/join-domain/elx/openldap-client/map.jinja
@@ -1,18 +1,8 @@
-{#- Grab the dns_name to use it in the defaults #}
-{%- set dns_name = salt.grains.get(
-    'join-domain:dns_name',
-    salt.pillar.get('join-domain:lookup:dns_name')
-) %}
-
-{#- Grab the ad_site_name to use it in the defaults #}
-{%- set ad_site_name = salt.grains.get(
-    'join-domain:ad_site_name',
-    salt.pillar.get('join-domain:lookup:ad_site_name')
-) %}
-
 {#- Set join-domain defaults for this ad connector #}
 {%- load_yaml as defaults %}
 
+ad_site_name: ''
+dns_name: ''
 oupath: ''
 
 {%- endload %}

--- a/join-domain/elx/pbis/files/join.sh
+++ b/join-domain/elx/pbis/files/join.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2181
+# shellcheck disable=SC2181,SC2236
 #
 # Helper-script to more-intelligently handle joining PBIS client
 # to domain. Script replaces "PBIS-join" cmd.run method with

--- a/pillar.example
+++ b/pillar.example
@@ -31,6 +31,7 @@ join-domain:
     key:
 
     # Optional domain-specific settings
+    #ad_site_name: 
     #oupath:
     #admin_users:
     #admin_groups:


### PR DESCRIPTION
With this change, when the domain collision-fixer script (`find-collisions.sh`) is run, it will attempt to restrict the list of domain-controllers consulted based on the value set via the `ad_site_name` key-value set in pillar:
~~~
# grep 'Completed state \[find-collisions.sh' ADstuff-2019-09-13-21\:29\:*.log
ADstuff-2019-09-13-21:29:09.debug.log:2019-09-13 21:29:13,953 [salt.state:1976][INFO][29015] Completed state [find-collisions.sh -d "test.aws.lab" -s "<SITE_NAME>" -u "<JOIN_USER>" -c "<CRYPT_STRING>" -k "<CRYPT_KEY>" --mode saltstack] at time 21:29:13.953038 (duration_in_ms=301.656)
~~~

...whereas, if no such key-value is set, no restriction attempt is made.

~~~
# grep 'Completed state \[find-collisions.sh' ADstuff-2019-09-13-21\:29\:*.log
ADstuff-2019-09-13-21:29:44.debug.log:2019-09-13 21:29:48,834 [salt.state:1976][INFO][29369] Completed state [find-collisions.sh -d "test.aws.lab" -u "<JOIN_USER>" -c "<CRYPT_STRING>" -k "<CRYPT_KEY>" --mode saltstack] at time 21:29:48.834193 (duration_in_ms=305.426)
~~~

Closes #140 
Closes #99 