### PR TITLE
Fixes BASEIP logic so command works and keeps shellcheck happy

### DIFF
--- a/join-domain/elx/pbis/files/fix-hostname.sh
+++ b/join-domain/elx/pbis/files/fix-hostname.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # The NETBIOS character-limit for hostnames is fifteen
 # characters. If PBIS attempts to join the host to a domain and
@@ -42,8 +42,7 @@ then
       exit 1
   else
       OLDFQDN=$(hostname)
-      CURDOM=$(awk -F = '/HOSTNAME/{print $2}' /etc/sysconfig/network | \
-              sed -e "s/$(hostname -s)\.//" -e 's/"//g')
+      CURDOM=$(hostname -d)
       read -ra IPTOKENS < <(ip addr show "${DEFIF}" | awk '/inet /{print $2}' | sed -e 's#/.*$##' -e 's/\./ /g')
       BASEIP=$(printf '%02X' "${IPTOKENS[@]}")
 

--- a/join-domain/elx/pbis/files/fix-hostname.sh
+++ b/join-domain/elx/pbis/files/fix-hostname.sh
@@ -43,7 +43,7 @@ then
   else
       OLDFQDN=$(hostname)
       CURDOM=$(awk -F = '/HOSTNAME/{print $2}' /etc/sysconfig/network | \
-              sed "s/$(hostname -s)\.//")
+              sed -e "s/$(hostname -s)\.//" -e 's/"//g')
       read -ra IPTOKENS < <(ip addr show "${DEFIF}" | awk '/inet /{print $2}' | sed -e 's#/.*$##' -e 's/\./ /g')
       BASEIP=$(printf '%02X' "${IPTOKENS[@]}")
 

--- a/join-domain/elx/pbis/files/fix-hostname.sh
+++ b/join-domain/elx/pbis/files/fix-hostname.sh
@@ -44,11 +44,8 @@ then
       OLDFQDN=$(hostname)
       CURDOM=$(awk -F = '/HOSTNAME/{print $2}' /etc/sysconfig/network | \
               sed "s/$(hostname -s)\.//")
-      BASEIP=$(printf '%02X' \
-              "$(ip addr show "${DEFIF}" | \
-                awk '/inet /{print $2}' | \
-                sed -e 's#/.*$##' -e 's/\./ /g' \
-              )")
+      read -ra IPTOKENS < <(ip addr show "${DEFIF}" | awk '/inet /{print $2}' | sed -e 's#/.*$##' -e 's/\./ /g')
+      BASEIP=$(printf '%02X' "${IPTOKENS[@]}")
 
       # Try to make new hostname fully-qualified
       if [[ ${CURDOM} = "" ]]


### PR DESCRIPTION
The quoting in the BASEIP logic is flawed and generates an error:

```
# BASEIP=$(printf '%02X' \
>               "$(ip addr show "${DEFIF}" | \
>                 awk '/inet /{print $2}' | \
>                 sed -e 's#/.*$##' -e 's/\./ /g' \
>               )")
-bash: printf: 10 0 5 99: invalid number
```

Moving the quotes to surround the entire command, including the printf, fixes the issue:

```
# read -ra IPTOKENS < <(ip addr show "${DEFIF}" | awk '/inet /{print $2}' | sed -e 's#/.*$##' -e 's/\./ /g')
# BASEIP=$(printf '%02X' "${IPTOKENS[@]}")
# echo $BASEIP
0A000563
```