### PR TITLE
Allows the setting of OS Name and Version AD-Attributes to be optional

### DIFF
--- a/join-domain/elx/sssd/files/join.sh
+++ b/join-domain/elx/sssd/files/join.sh
@@ -8,6 +8,8 @@ JOIN_DOMAIN="${JOIN_DOMAIN:-UNDEF}"
 JOIN_OU="${JOIN_OU:-}"
 JOIN_USER="${JOIN_USER:-Administrator}"
 JOIN_CNAME="${JOIN_CNAME:-UNDEF}"
+OS_NAME_SET="${OS_NAME_SET:-False}"
+OS_VERS_SET="${OS_VERS_SET:-False}"
 PWCRYPT="${ENCRYPT_PASS:-UNDEF}"
 PWUNLOCK="${ENCRYPT_KEY:-UNDEF}"
 CLIENT_OSNAME="$(
@@ -52,6 +54,8 @@ function IsDiscoverable {
 # Try to join host to domain
 function JoinDomain {
 
+  local AD_ATTRIB_OPTS
+
   # Toggle SELinux if necessary
   if [[ $( getenforce ) == "Enforcing" ]]
   then
@@ -63,6 +67,16 @@ function JoinDomain {
     SEL_TARG=0
   fi
 
+  if [[ ${OS_NAME_SET} = "True" ]]
+  then
+      AD_ATTRIB_OPTS="${AD_ATTRIB_OPTS} --os-name=${CLIENT_OSNAME}"
+  fi
+
+  if [[ ${OS_VERS_SET} = "True" ]]
+  then
+      AD_ATTRIB_OPTS="${AD_ATTRIB_OPTS} --os-version=${CLIENT_OSVERS}"
+  fi
+
   if [[ -z ${JOIN_OU} ]]
   then
     printf "Joining to %s... " "${JOIN_DOMAIN}"
@@ -70,8 +84,8 @@ function JoinDomain {
     echo "$( PWdecrypt )" | \
     realm join -U "${JOIN_USER}" \
       --unattended \
-      --os-name="${CLIENT_OSNAME}" \
-      --os-version="${CLIENT_OSVERS}" "${JOIN_DOMAIN}" > /dev/null 2>&1 || \
+      "${AD_ATTRIB_OPTS}" \
+      "${JOIN_DOMAIN}" > /dev/null 2>&1 || \
     ( echo "FAILED" ; exit 1)
     echo "Success"
 
@@ -82,9 +96,9 @@ function JoinDomain {
     echo "$( PWdecrypt )" | \
     realm join -U "${JOIN_USER}" \
       --unattended \
+      "${AD_ATTRIB_OPTS}" \
       --computer-ou="${JOIN_OU}" \
-      --os-name="${CLIENT_OSNAME}" \
-      --os-version="${CLIENT_OSVERS}" "${JOIN_DOMAIN}" > /dev/null 2>&1 || \
+      "${JOIN_DOMAIN}" > /dev/null 2>&1 || \
     ( echo "FAILED" ; exit 1)
     echo "Success"
   else

--- a/join-domain/elx/sssd/files/join.sh
+++ b/join-domain/elx/sssd/files/join.sh
@@ -81,11 +81,11 @@ function JoinDomain {
   if [[ -z ${JOIN_OU} ]]
   then
     printf "Joining to %s... " "${JOIN_DOMAIN}"
-    # shellcheck disable=SC2005
+    # shellcheck disable=SC2005,SC2086
     echo "$( PWdecrypt )" | \
     realm join -U "${JOIN_USER}" \
       --unattended \
-      "${AD_ATTRIB_OPTS}" \
+      ${AD_ATTRIB_OPTS} \
       "${JOIN_DOMAIN}" > /dev/null 2>&1 || \
     ( echo "FAILED" ; exit 1)
     echo "Success"
@@ -93,11 +93,11 @@ function JoinDomain {
   elif [[ -n ${JOIN_OU} ]]
   then
     printf "Joining to %s under %s OU... " "${JOIN_DOMAIN}" "${JOIN_OU}"
-    # shellcheck disable=SC2005
+    # shellcheck disable=SC2005,SC2086
     echo "$( PWdecrypt )" | \
     realm join -U "${JOIN_USER}" \
       --unattended \
-      "${AD_ATTRIB_OPTS}" \
+      ${AD_ATTRIB_OPTS} \
       --computer-ou="${JOIN_OU}" \
       "${JOIN_DOMAIN}" > /dev/null 2>&1 || \
     ( echo "FAILED" ; exit 1)

--- a/join-domain/elx/sssd/files/join.sh
+++ b/join-domain/elx/sssd/files/join.sh
@@ -55,6 +55,7 @@ function IsDiscoverable {
 function JoinDomain {
 
   local AD_ATTRIB_OPTS
+  AD_ATTRIB_OPTS=""
 
   # Toggle SELinux if necessary
   if [[ $( getenforce ) == "Enforcing" ]]

--- a/join-domain/elx/sssd/init.sls
+++ b/join-domain/elx/sssd/init.sls
@@ -57,6 +57,8 @@ join_realm-{{ join_domain.dns_name }}:
       - JOIN_DOMAIN: '{{ join_domain.dns_name }}'
       - JOIN_OU: '{{ join_domain.oupath }}'
       - JOIN_USER: '{{ join_domain.username }}'
+      - OS_NAME_SET: '{{ join_domain.attrib_bool_name }}'
+      - OS_VERS_SET: '{{ join_domain.attrib_bool_vers }}'
     - cwd: '/root'
     - name: 'join.sh'
     - require:

--- a/join-domain/elx/sssd/map.jinja
+++ b/join-domain/elx/sssd/map.jinja
@@ -7,9 +7,11 @@
 {#- Set join-domain defaults for this ad connector #}
 {%- load_yaml as defaults %}
 
-oupath: ''
+attrib_bool_name: 'False'
+attrib_bool_vers: 'False'
 login_home: '/home/%d/%u'
 login_shell: /bin/bash
+oupath: ''
 
 {%- endload %}
 


### PR DESCRIPTION
Closes #172 

New behavior defaults to _not_ attempting to set either the OS Name or OS Version AD-attributes. It's now explicitly required that  environment-variables:

- OS_NAME_SET
- OS_VERS_SET

Be set to `True` in order for either/both  variables to cause the `sssd` module's `join.sh` script to attempt to set the AD-attributes
