### PR TITLE
Removes windows computer object if found, unconditionally

### DIFF
--- a/join-domain/windows/files/JoinDomain.ps1
+++ b/join-domain/windows/files/JoinDomain.ps1
@@ -640,9 +640,17 @@ if($DomainJoinStatus -eq $null)
     }
 
     #Try to add the computer to the domain until AD catches up
-    Retry-TestCommand -Test xAdd-Computer -Args @{DomainName=$DomainName; Credential=$cred; TargetOU=$TargetOU; args=@{Options="JoinWithNewName,AccountCreate"; Force=$true; Verbose=$true; Passthru=$true; ErrorAction="SilentlyContinue";}} -Tries $Tries -InitialDelay 10 -TestProperty "hasSucceeded"
-    Write-Host "changed=yes comment=`"Joined system to the domain [$DomainName].`" domain=$DomainName";
+    try
+    {
+      Retry-TestCommand -Test xAdd-Computer -Args @{DomainName=$DomainName; Credential=$cred; TargetOU=$TargetOU; args=@{Options="JoinWithNewName,AccountCreate"; Force=$true; Verbose=$true; Passthru=$true; ErrorAction="SilentlyContinue";}} -Tries $Tries -InitialDelay 10 -TestProperty "hasSucceeded"
+    }
+    catch
+    {
+      Get-Content "${env:windir}\debug\NetSetup.log"
+      throw
+    }
 
+    Write-Host "changed=yes comment=`"Joined system to the domain [$DomainName].`" domain=$DomainName";
 }
 elseif($DomainJoinStatus -eq $DomainName)
 {

--- a/join-domain/windows/files/JoinDomain.ps1
+++ b/join-domain/windows/files/JoinDomain.ps1
@@ -635,12 +635,8 @@ if($DomainJoinStatus -eq $null)
     $result = Find-LdapObject -LdapConnection:$Ldap -SearchFilter:$SearchFilter -SearchBase:$OUSearchBase -propertiesToLoad:@("distinguishedName") -ErrorAction SilentlyContinue
     if($result)
     {
-        $resultOU = $result.distinguishedName.substring((($result.distinguishedName -replace '\,(.*)').length+1))
-        if($resultOU -ne $TargetOU)
-        {
-            #if the computer object is found in AD, remove it
-            Remove-LdapObject $result.distinguishedName -LdapConnection:$Ldap
-        }
+        #if the computer object is found in AD, remove it
+        Remove-LdapObject $result.distinguishedName -LdapConnection:$Ldap
     }
 
     #Try to add the computer to the domain until AD catches up


### PR DESCRIPTION
I *think* this test was keeping this function from removing a found
computer object. At one point in time, that was fine, as the Add-Computer
commandlet would go ahead and replace or reuse it, if needed. However, on
domain controllers with a reasonably current set of patches, that is not
allowed. It will fail with errors and a log similar to the below, in
%windir%\debug\netsetup.log.

```
NetpCheckForDomainSIDCollision: returning 0x0(0).
NetpGetComputerObjectDn: Cracking DNS domain name ..../ into Netbios on \\....
NetpGetComputerObjectDn: Crack results:         name = ....\
NetpGetComputerObjectDn: Cracking account name ....$ on \\....
NetpGetComputerObjectDn: Crack results:         (Account already exists) DN = CN=....
NetpGetADObjectOwnerAttributes: Looking up attributes for machine account: CN=....
NetpGetADObjectOwnerAttributes: Ms-Ds-CreatorSid is empty.
NetpGetNCData: Reading NC data
NetpReadAccountReuseModeFromAD: Searching '<WKGUID=....>' for '(&(ObjectClass=ServiceConnectionPoint)(KeyWords=NetJoin*))'.
NetpReadAccountReuseModeFromAD: Got 0 Entries.
Returning NetStatus: 0, ADReuseMode: 0
IsLegacyAccountReuseSetInRegistry: RegQueryValueEx for 'NetJoinLegacyAccountReuse' returned Status: 0x2.
IsLegacyAccountReuseSetInRegistry returning: 'FALSE''.
NetpDsValidateComputerAccountReuseAttempt: returning NtStatus: 0, NetStatus: 0
NetpDsValidateComputerAccountReuseAttempt: returning Result: FALSE
NetpCheckIfAccountShouldBeReused: Active Directory Policy check returned NetStatus:0x0.
NetpCheckIfAccountShouldBeReused:fReuseAllowed: FALSE, NetStatus:0x0
NetpModifyComputerObjectInDs: Account exists and re-use is blocked by policy. Error: 0xaac
NetpProvisionComputerAccount: LDAP creation failed: 0xaac
NetpProvisionComputerAccount: Cannot retry downlevel, specifying OU is not supported
ldap_unbind status: 0x0
NetpJoinCreatePackagePart: status:0xaac.
NetpJoinDomainOnDs: Function exits with status of: 0xaac
```