### PR TITLE
Update to attempt LDAP+TLS If available

### DIFF
--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -275,7 +275,7 @@ function FindComputer {
   local SHORTHOST
 
   # AD-hosted objects will always be shortnames
-  SHORTHOST=${HOSTNAME//.*/}
+  SHORTHOST=${JOIN_CLIENT//.*/}
 
   # Need to ensure we look for literal, all-cap and all-lower
   SEARCHTERM="(&(objectCategory=computer)(|(cn=${SHORTHOST})(cn=${SHORTHOST^^})(cn=${SHORTHOST,,})))"
@@ -437,7 +437,7 @@ do
               exit 1
               ;;
             *)
-              HOSTNAME="${2}"
+              JOIN_CLIENT="${2}"
               shift 2;
               ;;
         esac
@@ -619,11 +619,11 @@ OBJECT_DN="$( FindComputer )"
 
 case "${OBJECT_DN}" in
   NOTFOUND)
-    err_exit "Coult not find ${HOSTNAME} in ${SEARCHSCOPE}" 1
+    err_exit "Coult not find ${JOIN_CLIENT} in ${SEARCHSCOPE}" 1
     CLEANUP="FALSE"
     ;;
   *)
-    err_exit "Found ${HOSTNAME} in ${SEARCHSCOPE}" 0
+    err_exit "Found ${JOIN_CLIENT} in ${SEARCHSCOPE}" 0
     ;;
 esac
 

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -56,6 +56,23 @@ function err_exit {
    fi
 }
 
+# SaltStack-compatible outputter
+function SaltOut {
+  if [[ ${OUTPUT} == SALTMODE ]]
+  then
+      case "${2}" in
+        no)
+            printf "\n"
+            printf "changed=no comment='%s'\n" "${1}"
+            ;;
+        yes)
+            printf "\n"
+            printf "changed=yes comment='%s'\n" "${1}"
+            ;;
+      esac
+  fi
+}
+
 # Verify tool-dependencies
 function VerifyDependencies {
   local CHKRPMS

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -107,7 +107,7 @@ function PingDirServ {
     # Overwrite global directory-server array with successfully-pinged
     # servers' info
     DS_LIST=("${GOOD_DS_LIST[@]}")
-    err_exit "Found ${#{GOOD_DS_LIST[@]} port-pingable directory servers"
+    err_exit "Found ${#{GOOD_DS_LIST[@]} port-pingable directory servers" 0
     return 0
   else
     err_exit "All candidate servers failed port-ping" 1
@@ -163,7 +163,7 @@ function CheckTLSsupt {
     fi
 
     # Add servers with good certs to list
-    if [[ ${#GOOD_DS_LIST[@]} -gt 0 ]]
+    if [[ ${GOOD_DS_LIST[@]+"${GOOD_DS_LIST[@]}"} -gt 0 ]]
     then
       # Overwrite global directory-server array with successfully-pinged
       # servers' info

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -8,12 +8,13 @@ set -euo pipefail
 PROGNAME="$( basename "${0}" )"
 ADSITE="${ADSITE:-}"
 BINDPASS="${CLEARPASS:-}"
+CHK_TLS_SPT="${CHK_TLS_SPT:-true}"
 CLEANUP="${CLEANUP:-TRUE}"
 CRYPTKEY="${CRYPTKEY:-}"
 CRYPTSTRING="${CRYPTSTRING:-}"
 DEBUG="${DEBUG:-false}"
 DIR_DOMAIN="${JOIN_DOMAIN:-}"
-DIRUSER="${JOIN_USER:-}"
+DIR_USER="${JOIN_USER:-}"
 DOMAINNAME="${JOIN_DOMAIN:-}"
 DS_LIST=()
 JOIN_CLIENT="${JOIN_CLIENT:-}"
@@ -22,7 +23,6 @@ LDAP_HOST="${LDAP_HOST:-}"
 LDAP_TYPE="${LDAP_TYPE:-AD}"
 LOGFACIL="${LOGFACIL:-kern.crit}"
 OUTPUT="${OUTPUT:-SALTMODE}"
-REQ_TLS="${REQ_TLS:-true}"
 
 # Make interactive-execution more-verbose unless explicitly told not to
 if [[ $( tty -s ) -eq 0 ]] && [[ ${DEBUG} == "UNDEF" ]]
@@ -548,7 +548,7 @@ do
               exit 1
               ;;
             *)
-              DIRUSER="${2}"
+              DIR_USER="${2}"
               shift 2;
               ;;
         esac
@@ -577,9 +577,9 @@ fi
 # Set directory-user value as appropriate
 if [[ ${LDAP_TYPE} == AD ]]
 then
-  QUERYUSER="${DIRUSER}@${DOMAINNAME}"
+  QUERYUSER="${DIR_USER}@${DOMAINNAME}"
 else
-  QUERYUSER="${DIRUSER}"
+  QUERYUSER="${DIR_USER}"
 fi
 export QUERYUSER
 
@@ -610,7 +610,7 @@ fi
 PingDirServ
 
 # Verify candidate directory servers' properly-functioning TLS support
-if [[ ${REQ_TLS} == "true" ]]
+if [[ ${CHK_TLS_SPT} == "true" ]]
 then
   err_exit "Performing TLS-support test" 0
   CheckTLSsupt

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -191,7 +191,11 @@ function PingDirServ {
     fi
   done
 
-  if [[ ${#GOOD_DS_LIST[@]-} -gt 0 ]]
+  # Looking for unbound vars doesn't work well in this function
+  set +u
+
+  # Check if we actually found any servers that properly-support TLS
+  if [[ ${#GOOD_DS_LIST[@]} -gt 0 ]]
   then
     # Overwrite global directory-server array with successfully-pinged
     # servers' info

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -107,7 +107,7 @@ function PingDirServ {
     # Overwrite global directory-server array with successfully-pinged
     # servers' info
     DS_LIST=("${GOOD_DS_LIST[@]}")
-    err_exit "Found ${#{GOOD_DS_LIST[@]} port-pingable directory servers" 0
+    err_exit "Found ${#DS_LIST[@]} port-pingable directory servers" 0
     return 0
   else
     err_exit "All candidate servers failed port-ping" 1

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -188,6 +188,12 @@ LDAPPASSWD="$( PWdecrypt )"
 
 CandidateDirServ
 PingDirServ
-CheckTLSsupt
+if [[ ${REQ_TLS} == "true" ]]
+then
+  err_exit "Performing TLS-support test" 0
+  CheckTLSsupt
+else
+  err_exit "Skipping TLS-support test" 0
+fi
 
 err_exit "Found ${#DS_LIST[@]} potentially-good directory servers" 0

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -174,6 +174,8 @@ function PingDirServ {
   local    DS_PORT
   local -a GOOD_DS_LIST
 
+  # Initialize to null
+  GOOD_DS_LIST=()
 
   for DIR_SERV in "${DS_LIST[@]}"
   do
@@ -189,7 +191,7 @@ function PingDirServ {
     fi
   done
 
-  if [[ ${#GOOD_DS_LIST[@]} -gt 0 ]]
+  if [[ ${#GOOD_DS_LIST[@]-} -gt 0 ]]
   then
     # Overwrite global directory-server array with successfully-pinged
     # servers' info
@@ -233,8 +235,6 @@ function CheckTLSsupt {
   local    DS_PORT
   local -a GOOD_DS_LIST
 
-  setenforce 0
-
   for DIR_SERV in "${DS_LIST[@]}"
   do
     DS_NAME="${DIR_SERV//*;/}"
@@ -255,7 +255,7 @@ function CheckTLSsupt {
 
     # shellcheck disable=SC2199
     # Add servers with good certs to list
-    if [[ ${GOOD_DS_LIST[@]+"${GOOD_DS_LIST[@]}"} -gt 0 ]]
+    if [[ ${#GOOD_DS_LIST[@]} -gt 0 ]]
     then
       # Overwrite global directory-server array with successfully-pinged
       # servers' info
@@ -269,8 +269,6 @@ function CheckTLSsupt {
       err_exit "${DS_NAME} failed cert-check" 0
     fi
   done
-
-  setenforce 1
 }
 
 function FindComputer {

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -16,7 +16,8 @@ DIR_DOMAIN="${JOIN_DOMAIN:-}"
 DIRUSER="${JOIN_USER:-}"
 DOMAINNAME="${JOIN_DOMAIN:-}"
 DS_LIST=()
-LDAPTYPE="AD"
+LDAPHOST="${LDAPHOST:-}"
+LDAPTYPE="${LDAPTYPE:-AD}"
 LDAP_AUTH_TYPE="-x"
 LOGFACIL="${LOGFACIL:-kern.crit}"
 OUTPUT="${OUTPUT:-SALTMODE}"
@@ -308,16 +309,19 @@ function FindComputer {
     err_exit "Found ${COMPUTERNAME}" 0
     echo "${COMPUTERNAME}"
   else
-    err_exit "Did not find ${COMPUTERNAME}" 0
+    err_exit "Did not find '${SHORTHOST}'" 0
     echo "NOTFOUND"
   fi
 
   case "${SEARCH_EXIT}" in
     0)
-      err_exit "Found ${COMPUTERNAME} on ${DS_HOST}"j 0
+      err_exit "Found '${COMPUTERNAME}' on ${DS_HOST}"j 0
+      ;;
+    49)
+      err_exit "Search for '${SHORTHOST}' failed due to invalid credentials" 1
       ;;
     *)
-      err_exit "Delete of ${DIRECTORY_OBJECT} with exit-code '${DELETE_EXIT}'" 1
+      err_exit "Search for '${SHORTHOST}' failed with exit-code '${SEARCH_EXIT}'" 1
       ;;
   esac
 }
@@ -349,13 +353,16 @@ function NukeComputer {
 
   case "${DELETE_EXIT}" in
     0)
-      err_exit "Delete of ${DIRECTORY_OBJECT} succeeded" 0
+      err_exit "Delete of '${DIRECTORY_OBJECT}' succeeded" 0
       ;;
     34)
-      err_exit "Delete of ${DIRECTORY_OBJECT} failed: bad DN syntax" 1
+      err_exit "Delete of '${DIRECTORY_OBJECT}' failed: bad DN syntax" 1
+      ;;
+    49)
+      err_exit "Delete of '${DIRECTORY_OBJECT}' failed: invalid credentials" 1
       ;;
     *)
-      err_exit "Delete of ${DIRECTORY_OBJECT} failed" 1
+      err_exit "Delete of '${DIRECTORY_OBJECT}' failed" 1
       ;;
   esac
 }

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -261,6 +261,8 @@ function NukeComputer {
   local DS_PORT
   local DELETE_EXIT
 
+  # Override abort-on-error so we can provide better output
+  set +e
 
   DS_INFO="${1}"
   DIRECTORY_OBJECT="${2}"
@@ -277,12 +279,17 @@ function NukeComputer {
 
   DELETE_EXIT="$?"
 
-  if [[ ${DELETE_EXIT} -eq 0 ]]
-  then
-    err_exit "Delete of ${DIRECTORY_OBJECT} succeeded" 0
-  else
-    err_exit "Delete of ${DIRECTORY_OBJECT} failed" 1
-  fi
+  case "${DELETE_EXIT}" in
+    0)
+      err_exit "Delete of ${DIRECTORY_OBJECT} succeeded" 0
+      ;;
+    34)
+      err_exit "Delete of ${DIRECTORY_OBJECT} failed: bad DN syntax" 1
+      ;;
+    *)
+      err_exit "Delete of ${DIRECTORY_OBJECT} failed" 1
+      ;;
+  esac
 }
 
 
@@ -348,7 +355,7 @@ esac
 # Delete detected collision
 if [[ ${CLEANUP} == "TRUE" ]]
 then
-  NukeComputer "${DS_LIST[0]}" "${HOSTNAME}"
+  NukeComputer "${DS_LIST[0]}" "${OBJECT_DN}"
 else
   err_exit "Script called with 'no-cleanup' requested" 0
 fi

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -626,7 +626,7 @@ OBJECT_DN="$( FindComputer )"
 
 case "${OBJECT_DN}" in
   NOTFOUND)
-    err_exit "Coult not find ${JOIN_CLIENT} in ${SEARCHSCOPE}" 1
+    err_exit "Could not find ${JOIN_CLIENT} in ${SEARCHSCOPE}" 0
     CLEANUP="FALSE"
     ;;
   *)

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -208,7 +208,7 @@ function PWdecrypt {
   # Bail if either of crypt-string or decrpytion-key are null
   if [[ -z ${CRYPTSTRING} ]] || [[ -z ${CRYPTKEY} ]]
   then
-    logIt "Missing keystring-decryption values" 1
+    err_exit "Missing keystring-decryption values" 1
   fi
 
   # Lets decrypt!
@@ -380,7 +380,7 @@ function NukeComputer {
 # Ensure parseable arguments have been passed
 if [[ $# -eq 0 ]]
 then
-  logIt "No arguments given. Aborting" 1
+  err_exit "No arguments given. Aborting" 1
 fi
 
 # Define flags to look for...
@@ -406,7 +406,7 @@ do
       -c|--join-crypt)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -419,7 +419,7 @@ do
       -d|--domain-name)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -432,7 +432,7 @@ do
       -f|--hostname)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -448,7 +448,7 @@ do
       -k|--join-key)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -461,7 +461,7 @@ do
       -l|--ldap-host)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -474,7 +474,7 @@ do
       --mode)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -498,7 +498,7 @@ do
       -p|--join-password)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -511,7 +511,7 @@ do
       -s|--ad-site)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -524,7 +524,7 @@ do
       -t|--ldap-type)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -533,7 +533,7 @@ do
               shift 2;
               ;;
             *)
-              logIt "Error: unsupported directory-type" 1
+              err_exit "Error: unsupported directory-type" 1
               shift 2;
               exit 1
               ;;
@@ -542,7 +542,7 @@ do
       -u|--join-user)
         case "$2" in
             "")
-              logIt "Error: option required but not specified" 1
+              err_exit "Error: option required but not specified" 1
               shift 2;
               exit 1
               ;;
@@ -557,7 +557,7 @@ do
         break
         ;;
       *)
-        logIt "Missing value" 1
+        err_exit "Missing value" 1
         exit 1
         ;;
   esac

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2236,SC2207
 #
 set -euo pipefail
 #
@@ -11,545 +10,126 @@ BINDPASS="${CLEARPASS:-}"
 CRYPTKEY="${CRYPTKEY:-}"
 CRYPTSTRING="${CRYPTSTRING:-}"
 DEBUGVAL="${DEBUG:-false}"
+DIR_DOMAIN="${JOIN_DOMAIN:-}"
 DIRUSER="${JOIN_USER:-}"
 DOEXIT="0"
 DOMAINNAME="${JOIN_DOMAIN:-}"
+DS_LIST=()
 LDAPTYPE="AD"
 LOGFACIL="user.err"
+REQ_TLS="${REQ_TLS:-true}"
 
-# Function-abort hooks
-trap "exit 1" TERM
-export TOP_PID=$$
 
-# Need to ignore value set in parent shell because that value is set
-# before any wam-initiated renames complete
-HOSTNAME=$( uname -n )
+# Get Candidate DCs
+function CandidateDirServ {
+  local DNS_SEARCH_STRING
 
-# Miscellaneous output-engine
-function logIt {
-  local LOGSTR
-  local ERREXT
-
-  LOGSTR="${1}"
-  ERREXT="${2:-}"
-
-  # Spit out message to calling-shell if debug-mode enabled
-  if [[ ${DEBUGVAL} == true ]]
+  # Select whether to try to use AD "sites"
+  if [[ -n ${ADSITE:-} ]]
   then
-      echo "${LOGSTR}" >&2
+    DNS_SEARCH_STRING="_ldap._tcp.${ADSITE}._sites.dc._msdcs.${DIR_DOMAIN}"
+  else
+    DNS_SEARCH_STRING="_ldap._tcp.dc._msdcs.${DIR_DOMAIN}"
   fi
 
-  # Send to syslog if passed message-code is non-zero
-  if [[ ! -z ${ERREXT} ]] && [[ ${ERREXT} -gt 0 ]]
-  then
-      logger -st "${PROGNAME}" -p ${LOGFACIL} "${LOGSTR}"
-      exit "${ERREXT}"
-  fi
-}
-
-# Stateful output messaging for Saltstack
-function saltOut {
-  if [[ ${OUTPUT} == SALTMODE ]]
-  then
-      case "${2}" in
-        no)
-            printf "\n"
-            printf "changed=no comment='%s'\n" "${1}"
-            ;;
-        yes)
-            printf "\n"
-            printf "changed=yes comment='%s'\n" "${1}"
-            ;;
-      esac
-  fi
-}
-
-# Print out a basic usage message
-function UsageMsg {
-  (
-      # Special cases
-      if [[ ! -z ${MISSINGARGS+x} ]]
-      then
-        printf "Failed to pass one or more mandatory arguments\n\n"
-      elif [[ ! -z ${EXCLUSIVEARGS+x} ]]
-      then
-        printf "Passed two or more exclusive arguments\n\n"
-      fi
-
-      echo "Usage: ${0} [GNU long option] [option] ..."
-      echo "  Options:"
-      printf "\t-a <AD_SITENAME> \n"
-      printf "\t-c <ENCRYPTED_PASSWORD>  \n"
-      printf "\t-d <LONG_DOMAIN_NAME>  \n"
-      printf "\t-f <FORCED_HOSTNAME>  \n"
-      printf "\t-h # print this message  \n"
-      printf "\t-k <DECRYPTION_KEY>  \n"
-      printf "\t-l <LDAP_QUERY_HOST>  \n"
-      printf "\t-t <LDAP_TYPE>  \n"
-      printf "\t-u <DIRECTORY_USER> \n"
-      echo "  GNU long options:"
-      printf "\t--domain-name <LONG_DOMAIN_NAME>  \n"
-      printf "\t--help # print this message  \n"
-      printf "\t--hostname <FORCED_HOSTNAME>  \n"
-      printf "\t--join-crypt <ENCRYPTED_PASSWORD>  \n"
-      printf "\t--join-key <DECRYPTION_KEY>  \n"
-      printf "\t--join-user <DIRECTORY_USER> \n"
-      printf "\t--ldap-host <LDAP_QUERY_HOST>  \n"
-      printf "\t--ldap-type <LDAP_TYPE> \n"
-      printf "\t--ad-site <AD_SITENAME> \n"
-  ) >&2
-  exit 1
-}
-
-# Verify tool-dependencies
-function VerifyDependencies {
-  local CHKRPMS
-  local RPM
-
-  # RPMs to check for
-  CHKRPMS=(
-        bind-utils
-        openldap-clients
-      )
-
-  for RPM in "${CHKRPMS[@]}"
-  do
-      printf "Is dependency on %s satisfied? " "${RPM}"
-      if [[ $( rpm --quiet -q "${RPM}" )$? -eq 0 ]]
-      then
-        echo "Yes"
-      else
-        ( echo "No. Aborting..." ; kill -s TERM " ${TOP_PID}" )
-      fi
-  done
-}
-
-# Decrypt Join Password
-function PWdecrypt {
-  local PWCLEAR
-
-  # Bail if either of crypt-string or decrpytion-key are null
-  if [[ -z ${CRYPTSTRING} ]] || [[ -z ${CRYPTKEY} ]]
-  then
-    logIt "Missing keystring-decryption values" 1
-  fi
-
-  # Lets decrypt!
-  if PWCLEAR=$(
-    echo "${CRYPTSTRING}" | \
-    openssl enc -aes-256-cbc -md sha256 -a -d -salt -pass pass:"${CRYPTKEY}"
+  # Populate global directory-server array
+  mapfile -t DS_LIST < <(
+    dig -t SRV "${DNS_SEARCH_STRING}" | \
+    sed -e '/^$/d' -e '/;/d' | \
+    awk '/\s\s*IN\s\s*SRV\s\s*/{ printf("%s;%s\n",$7,$8) }' | \
+    sed -e 's/\.$//'
   )
+
+  if [[ ${#DS_LIST[@]} -eq 0 ]]
   then
-    echo "${PWCLEAR}"
+    echo "Unable to generate a list of candidate servers"
+    return 1
+  else
+    echo "Found ${#DS_LIST[@]} candidate directory-servers"
+    return 0
+  fi
+}
+
+# Make sure directory-server ports are open
+function PingDirServ {
+  local    DIR_SERV
+  local    DS_NAME
+  local    DS_PORT
+  local -a GOOD_DS_LIST
+
+
+  for DIR_SERV in "${DS_LIST[@]}"
+  do
+    DS_NAME="${DIR_SERV//*;/}"
+    DS_PORT="${DIR_SERV//;*/}"
+
+    if [[ $(
+        timeout 1 bash -c "echo > /dev/tcp/${DS_NAME}/${DS_PORT}"
+      ) -eq 0 ]]
+    then
+      GOOD_DS_LIST+=("${DIR_SERV}")
+      echo "${DIR_SERV//*;} responds to port-ping"
+    fi
+  done
+
+  if [[ ${#GOOD_DS_LIST[@]} -gt 0 ]]
+  then
+    # Overwrite global directory-server array with successfully-pinged
+    # servers' info
+    DS_LIST=("${GOOD_DS_LIST[@]}")
     return 0
   else
-    echo "Decryption FAILED!"
+    echo "All candidate servers failed port-ping"
     return 1
   fi
 }
 
-# Find domain controllers to talk to
-function FindDCs {
-  local DNS_SEARCH_STRING
-  local IDX
-  local DC
+# Check if directory-servers support TLS
+function CheckTLSsupt {
+  local    DIR_SERV
+  local    DS_NAME
+  local    DS_PORT
+  local -a GOOD_DS_LIST
 
-  # Select whether to try to use AD
-  if [[ ! -z ${ADSITE:-} ]]
-  then
-      DNS_SEARCH_STRING="_ldap._tcp.${ADSITE}._sites.dc._msdcs.${1}"
-  else
-      DNS_SEARCH_STRING="_ldap._tcp.dc._msdcs.${1}"
-  fi
+  for DIR_SERV in "${DS_LIST[@]}"
+  do
+    DS_NAME="${DIR_SERV//*;/}"
+    DS_PORT="${DIR_SERV//;*/}"
 
-  export DNS_SEARCH_STRING
+    if [[ $(
+        echo | \
+        openssl s_client -showcerts -starttls ldap \
+          -connect "${DS_NAME}:${DS_PORT}" 2> /dev/null | \
+        openssl verify > /dev/null 2>&1
+      )$? -eq 0 ]]
+    then
+      GOOD_DS_LIST+=("${DIR_SERV}")
+      echo appending
+    fi
 
-  IDX=0
-  DC=($(
-        dig -t SRV "${DNS_SEARCH_STRING}" | sed -e '/^$/d' -e '/;/d' | \
-        awk '/\s\s*IN\s\s*SRV\s\s*/{ printf("%s;%s\n",$7,$8) }' | \
-        sed -e 's/\.$//'
-      ))
-
-  # Parse list of domain-controllers to see who we can connect to
-  if [[ ${#DC} -ne 0 ]]
-  then
-      for CTLR in "${DC[@]}"
-      do
-        DC[${IDX}]="${CTLR}"
-        timeout 1 bash -c "echo > /dev/tcp/${CTLR//*;/}/${CTLR//;*/}" &&
-          break
-        IDX=$(( IDX + 1 ))
-      done
-
-      case "${DC[${IDX}]//;*/}" in
-        389)
-          logIt "Contact ${DC[${IDX}]//*;/} on port ${DC[${IDX}]//;*/}" 0
-            ;;
-        636)
-          logIt "Contact ${DC[${IDX}]//*;/} on port ${DC[${IDX}]//;*/}" 0
-            ;;
-        *)
-          logIt "${DC[${IDX}]//*;/} listening on unrecognized port [${DC[${IDX}]//;*/}]" 1
-            ;;
-      esac
-
-      # Return info
-      echo "${DC[${IDX}]}"
-  else
-      # Return error
-      echo "DC_NOT_FOUND"
-  fi
-
-}
-
-# Find computer's DN
-function FindComputer {
-  local COMPUTERNAME
-  local SEARCHEXIT
-  local SEARCHTERM
-  local SHORTHOST
-
-  # AD-hosted objects will always be shortnames
-  SHORTHOST=${HOSTNAME//.*/}
-
-  # Need to ensure we look for literal, all-cap and all-lower
-  SEARCHTERM="(&(objectCategory=computer)(|(cn=${SHORTHOST})(cn=${SHORTHOST^^})(cn=${SHORTHOST,,})))"
-  export SEARCHTERM
-
-  # Searach without STARTLS
-  COMPUTERNAME=$(
-      ldapsearch \
-        -o ldif-wrap=no \
-        -LLL \
-        -Zx \
-        -h "${DCINFO//*;/}" \
-        -p "${DCINFO//;*/}" \
-        -D "${QUERYUSER}" \
-        -w "${BINDPASS}" \
-        -b "${SEARCHSCOPE}" \
-        -s sub "${SEARCHTERM}" dn
-  )
-
-  COMPUTERNAME=$( echo "${COMPUTERNAME}" | \
-        sed -e 's/^.*dn: *//' -e '/^$/d' -e '/#/d' )
-
-  # Output based on exit status and/or what's found
-  if [[ -z ${COMPUTERNAME} ]]
-  then
-      echo "NOTFOUND"
-  else
-      echo "${COMPUTERNAME}"
-  fi
-}
-
-# Nuke computer's DN
-function NukeObject {
-  local SEARCHEXIT
-  local LDAPOBJECT
-
-  LDAPOBJECT="${1}"
-
-  ldapdelete -x -h "${DCINFO//*;/}" -p "${DCINFO//;*/}" -D "${QUERYUSER}" \
-    -w "${BINDPASS}" "${LDAPOBJECT}" 2> /dev/null || \
-  ldapdelete -Z -x -h "${DCINFO//*;/}" -p "${DCINFO//;*/}" -D "${QUERYUSER}" \
-    -w "${BINDPASS}" "${LDAPOBJECT}" 2> /dev/null
-
-  SEARCHEXIT="$?"
-
-  if [[ ${SEARCHEXIT} -eq 0 ]]
-  then
-      logIt "Delete of ${LDAPOBJECT} succeeded" 0
-      saltOut "Delete of computer-object [${HOSTNAME}] succeeded" yes
-  else
-      logIt "Delete of ${LDAPOBJECT} failed" 0
-      saltOut "Delete of computer-object [${HOSTNAME}] failed" no
-  fi
+    # Add servers with good certs to list
+    if [[ ${#GOOD_DS_LIST[@]} -gt 0 ]]
+    then
+      # Overwrite global directory-server array with successfully-pinged
+      # servers' info
+      DS_LIST=("${GOOD_DS_LIST[@]}")
+      return 0
+    else
+      # Null the list
+      DS_LIST=()
+      echo "${DS_NAME} failed cert-check"
+    fi
+  done
 }
 
 
 
-#######################
-## Main Program Flow ##
-#######################
+################
+# Main program #
+################
 
-# Ensure parseable arguments have been passed
-if [[ $# -eq 0 ]]
-then
-  logIt "No arguments given. Aborting" 1
-fi
+CandidateDirServ
+PingDirServ
+CheckTLSsupt
 
-# Define flags to look for...
-OPTIONBUFR=$(getopt -o c:d:f:hk:l:p:s:t:u: --long domain-name:,help,hostname:,join-crypt:,join-key:,join-password:,join-user:,ldap-host:,ldap-type:,mode:,ad-site: -n "${PROGNAME}" -- "$@")
-
-# Check for mutually-exclusive arguments
-if [[ ${OPTIONBUFR} =~ p\ |join-password && ${OPTIONBUFR} =~ c\ |join-crypt ]] ||
-  [[ ${OPTIONBUFR} =~ p\ |join-password && ${OPTIONBUFR} =~ c\ |join-key ]]
-then
-  EXCLUSIVEARGS=TRUE
-  UsageMsg
-fi
-
-
-eval set -- "${OPTIONBUFR}"
-
-###################################
-# Parse contents of ${OPTIONBUFR}
-###################################
-while true
-do
-  case "$1" in
-      -c|--join-crypt)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            *)
-              CRYPTSTRING="${2}"
-              shift 2;
-              ;;
-        esac
-        ;;
-      -d|--domain-name)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            *)
-              DOMAINNAME="${2}"
-              shift 2;
-              ;;
-        esac
-        ;;
-      -f|--hostname)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            *)
-              HOSTNAME="${2}"
-              shift 2;
-              ;;
-        esac
-        ;;
-      -h|--help)
-        UsageMsg
-        ;;
-      -k|--join-key)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            *)
-              CRYPTKEY="${2}"
-              shift 2;
-              ;;
-        esac
-        ;;
-      -l|--ldap-host)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            *)
-              LDAPHOST="${2}"
-              shift 2;
-              ;;
-        esac
-        ;;
-      --mode)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            cleanup)
-              CLEANUP=TRUE
-              OUTPUT=INTERACTIVE
-              shift 2;
-              ;;
-            saltstack)
-              CLEANUP=TRUE
-              OUTPUT=SALTMODE
-              shift 2;
-              ;;
-            *)
-              CLEANUP=FALSE
-              OUTPUT=INTERACTIVE
-              shift 2;
-              ;;
-        esac
-        ;;
-      -p|--join-password)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            *)
-              BINDPASS="${2}"
-              shift 2;
-              ;;
-        esac
-        ;;
-      -s|--ad-site)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            *)
-              ADSITE="${2}"
-              shift 2;
-              ;;
-        esac
-        ;;
-      -t|--ldap-type)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            ad|AD)
-              LDAPTYPE="AD"
-              shift 2;
-              ;;
-            *)
-              logIt "Error: unsupported directory-type" 1
-              shift 2;
-              exit 1
-              ;;
-        esac
-        ;;
-      -u|--join-user)
-        case "$2" in
-            "")
-              logIt "Error: option required but not specified" 1
-              shift 2;
-              exit 1
-              ;;
-            *)
-              DIRUSER="${2}"
-              shift 2;
-              ;;
-        esac
-        ;;
-      --)
-        shift
-        break
-        ;;
-      *)
-        logIt "Missing value" 1
-        exit 1
-        ;;
-  esac
-done
-
-# Check that mandatory options have been passed
-if [[ -z ${DOMAINNAME} ]] ||
-  [[ -z ${DIRUSER} ]]
-then
-  MISSINGARGS=true
-  UsageMsg
-fi
-
-# Ensure dependencies are met
-VerifyDependencies
-
-# Decrypt our query password (as necessary)
-if [[ -z ${BINDPASS} ]]
-then
-  BINDPASS="$(PWdecrypt)"
-  export BINDPASS
-
-  # Bail if needed decrypt failed
-  if [[ ${BINDPASS} == "FAILURE" ]]
-  then
-      logIt "Failed decrypting password"
-      saltOut "Failed decrypting password" no
-      exit
-  fi
-fi
-
-
-# Search for Domain Controllers
-if [[ -z ${LDAPHOST+x} ]]
-then
-  DCINFO="$( FindDCs "${DOMAINNAME}" )"
-else
-  DCINFO="389;${LDAPHOST}"
-fi
-export DCINFO
-
-# Set directory-user value as appropriate
-if [[ ${LDAPTYPE} == AD ]]
-then
-  QUERYUSER="${DIRUSER}@${DOMAINNAME}"
-else
-  QUERYUSER="${DIRUSER}"
-fi
-export QUERYUSER
-
-# Convert domain to a search scope
-SEARCHSCOPE="$( printf "DC=%s" "${DOMAINNAME//./,DC=}" )"
-export SEARCHSCOPE
-
-# Do search
-if [[ ${DCINFO} = DC_NOT_FOUND ]]
-then
-  OBJECTDN="${DCINFO}"
-else
-  OBJECTDN=$(FindComputer)
-fi
-
-case "${OBJECTDN}" in
-  DC_NOT_FOUND)
-      logIt "Could not find domain-controller to query for ${HOSTNAME}" "${DOEXIT}"
-      saltOut "Could not find domain-controller to query for ${HOSTNAME}" no
-      logIt "Skipping any requested cleanup attempts"
-      CLEANUP="FALSE"
-      ;;
-  NOTFOUND)
-      if [[ ${OUTPUT} != SALTMODE ]]
-      then
-        DOEXIT=1
-      fi
-      logIt "Could not find ${HOSTNAME} in ${SEARCHSCOPE}" "${DOEXIT}"
-      saltOut "Could not find computer-object [${HOSTNAME}] in directory" no
-      logIt "Skipping any requested cleanup attempts"
-      CLEANUP="FALSE"
-      ;;
-  QUERYFAILURE)
-      if [[ ${OUTPUT} != SALTMODE ]]
-      then
-        DOEXIT=1
-      fi
-      logIt "Query failure when looking for ${HOSTNAME} in ${SEARCHSCOPE}" "${DOEXIT}"
-      saltOut "Query failure when looking for computer-object [${HOSTNAME}] in directory" no
-      logIt "Skipping any requested cleanup attempts"
-      CLEANUP="FALSE"
-      ;;
-  *)
-      logIt "Found ${OBJECTDN}"
-      ;;
-esac
-
-# Whether to try to NUKE
-if [[ ${CLEANUP} == TRUE ]]
-then
-  NukeObject "${OBJECTDN}"
-fi
+echo "${#DS_LIST[@]}"

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -242,16 +242,23 @@ function FindComputer {
   COMPUTERNAME=$( echo "${COMPUTERNAME}" | \
         sed -e 's/^.*dn: *//' -e '/^$/d' -e '/#/d' )
 
-  # Output based on exit status and/or what's found
-  if [[ -z ${COMPUTERNAME} ]]
+  if [[ -n ${COMPUTERNAME:-} ]]
   then
-      err_exit "Did not find ${COMPUTERNAME}"
-      echo "NOTFOUND"
+    err_exit "Found ${COMPUTERNAME}" 0
+    echo "${COMPUTERNAME}"
   else
-      err_exit "Found ${COMPUTERNAME}"
-      echo "${COMPUTERNAME}"
+    err_exit "Did not find ${COMPUTERNAME}" 0
+    echo "NOTFOUND"
   fi
 
+  case "${SEARCH_EXIT}" in
+    0)
+      err_exit "Found ${COMPUTERNAME} on ${DS_HOST}"j 0
+      ;;
+    *)
+      err_exit "Delete of ${DIRECTORY_OBJECT} with exit-code '${DELETE_EXIT}'" 1
+      ;;
+  esac
 }
 
 function NukeComputer {

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -233,6 +233,8 @@ function CheckTLSsupt {
   local    DS_PORT
   local -a GOOD_DS_LIST
 
+  setenforce 0
+
   for DIR_SERV in "${DS_LIST[@]}"
   do
     DS_NAME="${DIR_SERV//*;/}"
@@ -240,7 +242,9 @@ function CheckTLSsupt {
 
     if [[ $(
         echo | \
-        openssl s_client -showcerts -starttls ldap \
+        timeout 15 openssl s_client \
+          -showcerts \
+          -starttls ldap \
           -connect "${DS_NAME}:${DS_PORT}" 2> /dev/null | \
         openssl verify > /dev/null 2>&1
       )$? -eq 0 ]]
@@ -265,6 +269,8 @@ function CheckTLSsupt {
       err_exit "${DS_NAME} failed cert-check" 0
     fi
   done
+
+  setenforce 1
 }
 
 function FindComputer {

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -162,6 +162,7 @@ function CheckTLSsupt {
       err_exit "Appending ${DS_NAME} to 'good servers' list" 0
     fi
 
+    # shellcheck disable=SC2199
     # Add servers with good certs to list
     if [[ ${GOOD_DS_LIST[@]+"${GOOD_DS_LIST[@]}"} -gt 0 ]]
     then

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -16,9 +16,9 @@ DIR_DOMAIN="${JOIN_DOMAIN:-}"
 DIRUSER="${JOIN_USER:-}"
 DOMAINNAME="${JOIN_DOMAIN:-}"
 DS_LIST=()
-LDAPHOST="${LDAPHOST:-}"
-LDAPTYPE="${LDAPTYPE:-AD}"
 LDAP_AUTH_TYPE="-x"
+LDAP_HOST="${LDAP_HOST:-}"
+LDAP_TYPE="${LDAP_TYPE:-AD}"
 LOGFACIL="${LOGFACIL:-kern.crit}"
 OUTPUT="${OUTPUT:-SALTMODE}"
 REQ_TLS="${REQ_TLS:-true}"
@@ -317,6 +317,9 @@ function FindComputer {
     0)
       err_exit "Found '${COMPUTERNAME}' on ${DS_HOST}"j 0
       ;;
+    32)
+      err_exit "Search for '${SHORTHOST}' failed due to 'no such object'" 1
+      ;;
     49)
       err_exit "Search for '${SHORTHOST}' failed due to invalid credentials" 1
       ;;
@@ -463,7 +466,7 @@ do
               exit 1
               ;;
             *)
-              LDAPHOST="${2}"
+              LDAP_HOST="${2}"
               shift 2;
               ;;
         esac
@@ -526,7 +529,7 @@ do
               exit 1
               ;;
             ad|AD)
-              LDAPTYPE="AD"
+              LDAP_TYPE="AD"
               shift 2;
               ;;
             *)
@@ -565,7 +568,7 @@ done
 ################
 
 # Set directory-user value as appropriate
-if [[ ${LDAPTYPE} == AD ]]
+if [[ ${LDAP_TYPE} == AD ]]
 then
   QUERYUSER="${DIRUSER}@${DOMAINNAME}"
 else
@@ -588,12 +591,12 @@ fi
 VerifyDependencies
 
 # Identify list of candidate directory servers
-if [[ -z ${LDAPHOST} ]]
+if [[ -z ${LDAP_HOST} ]]
 then
   CandidateDirServ
 else
   DS_LIST=()
-  DS_LIST[0]="${LDAPHOST}"
+  DS_LIST[0]="${LDAP_HOST}"
 fi
 
 # Port-ping candidate directory servers

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -16,6 +16,7 @@ DIR_DOMAIN="${JOIN_DOMAIN:-}"
 DIRUSER="${JOIN_USER:-}"
 DOMAINNAME="${JOIN_DOMAIN:-}"
 DS_LIST=()
+JOIN_CLIENT="${JOIN_CLIENT:-}"
 LDAP_AUTH_TYPE="-x"
 LDAP_HOST="${LDAP_HOST:-}"
 LDAP_TYPE="${LDAP_TYPE:-AD}"
@@ -566,6 +567,12 @@ done
 ################
 # Main program #
 ################
+
+# Set AD-client hostname if not previously set by other means
+if [[ -z ${JOIN_CLIENT} ]]
+then
+  JOIN_CLIENT="$( hostname -f )"
+fi
 
 # Set directory-user value as appropriate
 if [[ ${LDAP_TYPE} == AD ]]

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -12,13 +12,42 @@ CRYPTSTRING="${CRYPTSTRING:-}"
 DEBUGVAL="${DEBUG:-false}"
 DIR_DOMAIN="${JOIN_DOMAIN:-}"
 DIRUSER="${JOIN_USER:-}"
-DOEXIT="0"
 DOMAINNAME="${JOIN_DOMAIN:-}"
 DS_LIST=()
 LDAPTYPE="AD"
 LOGFACIL="user.err"
 REQ_TLS="${REQ_TLS:-true}"
 
+# Make interactive-execution more-verbose unless explicitly told not to
+if [[ $( tty -s ) -eq 0 ]] && [[ ${DEBUG} == "UNDEF" ]]
+then
+   DEBUG="true"
+fi
+
+# Error handler function
+function err_exit {
+   local ERRSTR
+   local ISNUM
+   local SCRIPTEXIT
+
+   ERRSTR="${1}"
+   ISNUM='^[0-9]+$'
+   SCRIPTEXIT="${2:-1}"
+
+   if [[ ${DEBUG} == true ]]
+   then
+      # Our output channels
+      logger -i -t "${PROGNAME}" -p kern.crit -s -- "${ERRSTR}"
+   else
+      logger -i -t "${PROGNAME}" -p kern.crit -- "${ERRSTR}"
+   fi
+
+   # Only exit if requested exit is numerical
+   if [[ ${SCRIPTEXIT} =~ ${ISNUM} ]]
+   then
+      exit "${SCRIPTEXIT}"
+   fi
+}
 
 # Get Candidate DCs
 function CandidateDirServ {

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -46,7 +46,7 @@ function err_exit {
    # Only exit if requested exit is numerical
    if [[ ${SCRIPTEXIT} =~ ${ISNUM} ]]
    then
-      exit "${SCRIPTEXIT}"
+      return "${SCRIPTEXIT}"
    fi
 }
 
@@ -72,10 +72,10 @@ function CandidateDirServ {
 
   if [[ ${#DS_LIST[@]} -eq 0 ]]
   then
-    echo "Unable to generate a list of candidate servers"
+    err_exit "Unable to generate a list of candidate servers" 1
     return 1
   else
-    echo "Found ${#DS_LIST[@]} candidate directory-servers"
+    err_exit "Found ${#DS_LIST[@]} candidate directory-servers" 0
     return 0
   fi
 }
@@ -98,7 +98,7 @@ function PingDirServ {
       ) -eq 0 ]]
     then
       GOOD_DS_LIST+=("${DIR_SERV}")
-      echo "${DIR_SERV//*;} responds to port-ping"
+      err_exit "${DIR_SERV//*;} responds to port-ping" 0
     fi
   done
 
@@ -107,9 +107,10 @@ function PingDirServ {
     # Overwrite global directory-server array with successfully-pinged
     # servers' info
     DS_LIST=("${GOOD_DS_LIST[@]}")
+    err_exit "Found ${#{GOOD_DS_LIST[@]} port-pingable directory servers"
     return 0
   else
-    echo "All candidate servers failed port-ping"
+    err_exit "All candidate servers failed port-ping" 1
     return 1
   fi
 }
@@ -158,7 +159,7 @@ function CheckTLSsupt {
       )$? -eq 0 ]]
     then
       GOOD_DS_LIST+=("${DIR_SERV}")
-      echo appending
+      err_exit "Appending ${DS_NAME} to 'good servers' list" 0
     fi
 
     # Add servers with good certs to list
@@ -171,7 +172,7 @@ function CheckTLSsupt {
     else
       # Null the list
       DS_LIST=()
-      echo "${DS_NAME} failed cert-check"
+      err_exit "${DS_NAME} failed cert-check" 0
     fi
   done
 }
@@ -188,4 +189,4 @@ CandidateDirServ
 PingDirServ
 CheckTLSsupt
 
-echo "${#DS_LIST[@]}"
+err_exit "Found ${#DS_LIST[@]} potentially-good directory servers" 0

--- a/join-domain/elx/openldap-client/find-collision.sls
+++ b/join-domain/elx/openldap-client/find-collision.sls
@@ -27,7 +27,7 @@ LDAP-FindCollison:
       - JOIN_DOMAIN: '{{ join_domain.dns_name }}'
       - JOIN_OU: '{{ join_domain.oupath }}'
       - JOIN_USER: '{{ join_domain.username }}'
-      - REQ_TLS: '{{ tls_check }}'
+      - CHK_TLS_SPT: '{{ tls_check }}'
 {%- if join_domain.ad_site_name and join_domain.get("encrypted_password") %}
     - name: 'find-collisions.sh -d "{{ join_domain.dns_name }}" -s "{{ join_domain.ad_site_name }}" --mode saltstack'
 {%- elif join_domain.ad_site_name and join_domain.get("password") %}

--- a/join-domain/elx/openldap-client/find-collision.sls
+++ b/join-domain/elx/openldap-client/find-collision.sls
@@ -25,6 +25,7 @@ LDAP-FindCollison:
       - JOIN_DOMAIN: '{{ join_domain.dns_name }}'
       - JOIN_OU: '{{ join_domain.oupath }}'
       - JOIN_USER: '{{ join_domain.username }}'
+      - REQ_TLS: '{{ join_domain.tls_check }}'
 {%- if join_domain.ad_site_name and join_domain.get("encrypted_password") %}
     - name: 'find-collisions.sh -d "{{ join_domain.dns_name }}" -s "{{ join_domain.ad_site_name }}" --mode saltstack'
 {%- elif join_domain.ad_site_name and join_domain.get("password") %}

--- a/join-domain/elx/openldap-client/find-collision.sls
+++ b/join-domain/elx/openldap-client/find-collision.sls
@@ -9,6 +9,8 @@
 {#- Set location for helper-files #}
 {%- set files = tpldir ~ '/files' %}
 
+{%- set tls_check = join_domain.tls_check, true %}
+
 RPM-installs:
   pkg.installed:
     - pkgs:
@@ -25,7 +27,7 @@ LDAP-FindCollison:
       - JOIN_DOMAIN: '{{ join_domain.dns_name }}'
       - JOIN_OU: '{{ join_domain.oupath }}'
       - JOIN_USER: '{{ join_domain.username }}'
-      - REQ_TLS: '{{ join_domain.tls_check }}'
+      - REQ_TLS: '{{ tls_check }}'
 {%- if join_domain.ad_site_name and join_domain.get("encrypted_password") %}
     - name: 'find-collisions.sh -d "{{ join_domain.dns_name }}" -s "{{ join_domain.ad_site_name }}" --mode saltstack'
 {%- elif join_domain.ad_site_name and join_domain.get("password") %}


### PR DESCRIPTION
Refactored. The server-suitability testing is now three phases:

1. Generate a list of candidate-servers from a DNS lookup
2. Do a port-ping of those servers to validate which ones are _reachable_ &ndash; remove from the suitable servers list any that aren't port-reachable 
3. Do a TLS validation-check &ndash; removing any that fail from the suitable servers list (defaults to "on" but can be disabled by explicitly setting the `CHK_TLS_SPT` env-var to `false`)

Closes #187