### PR TITLE
Better integrates the openldap-client module with the sssd module

### DIFF
--- a/join-domain/elx/init.sls
+++ b/join-domain/elx/init.sls
@@ -10,6 +10,5 @@
 ) %}
 
 include:
-  - .openldap-client.find-collision
   - .{{ ad_connector }}
   - .auth-config

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -334,6 +334,9 @@ function FindComputer {
     0)
       err_exit "Found '${COMPUTERNAME}' on ${DS_HOST}" 0
       ;;
+    8)
+      err_exit "Search for '${SHORTHOST}' failed due insufficient auth-strength selection" 1
+      ;;
     32)
       err_exit "Search for '${SHORTHOST}' failed due to 'no such object'" 1
       ;;

--- a/join-domain/elx/openldap-client/files/find-collisions.sh
+++ b/join-domain/elx/openldap-client/files/find-collisions.sh
@@ -55,9 +55,12 @@ function err_exit {
   fi
 
   # Only exit if requested exit is numerical
-  if [[ ${SCRIPTEXIT} =~ ${ISNUM} ]]
+  if [[ ${SCRIPTEXIT} =~ ${ISNUM} ]] && [[ ${LDAP_FATAL_EXIT} == "true" ]]
   then
     return "${SCRIPTEXIT}"
+  elif [[ ${SCRIPTEXIT} =~ ${ISNUM} ]] && [[ ${LDAP_FATAL_EXIT} == "false" ]]
+  then
+    return 0
   fi
 }
 

--- a/join-domain/elx/openldap-client/find-collision.sls
+++ b/join-domain/elx/openldap-client/find-collision.sls
@@ -20,12 +20,13 @@ LDAP-FindCollison:
   cmd.script:
     - cwd: '/root'
     - env:
-      - CRYPTSTRING: '{{ join_domain.encrypted_password }}'
       - CRYPTKEY: '{{ join_domain.key }}'
+      - CRYPTSTRING: '{{ join_domain.encrypted_password }}'
       - JOIN_DOMAIN: '{{ join_domain.dns_name }}'
       - JOIN_OU: '{{ join_domain.oupath }}'
       - JOIN_USER: '{{ join_domain.username }}'
-      - CHK_TLS_SPT: '{{ join_domain.tls_check }}'
+      - LDAP_FATAL_EXIT: '{{ join_domain.ldap_fatal_exit }}'
+      - USE_TLS_OPTION: '{{ join_domain.ldap_tls_mode }}'
 {%- if join_domain.ad_site_name and join_domain.get("encrypted_password") %}
     - name: 'find-collisions.sh -d "{{ join_domain.dns_name }}" -s "{{ join_domain.ad_site_name }}" --mode saltstack'
 {%- elif join_domain.ad_site_name and join_domain.get("password") %}

--- a/join-domain/elx/openldap-client/map.jinja
+++ b/join-domain/elx/openldap-client/map.jinja
@@ -4,7 +4,8 @@
 ad_site_name: ''
 dns_name: ''
 oupath: ''
-tls_check: 'true'
+ldap_tls_mode: 'try'
+ldap_fatal_exit: 'false'
 
 {%- endload %}
 

--- a/join-domain/elx/sssd/init.sls
+++ b/join-domain/elx/sssd/init.sls
@@ -9,6 +9,15 @@
 {%- set joiner_files = tpldir ~ '/files' %}
 {%- set common_tools = 'salt://' ~ salt.file.dirname(tpldir) ~ '/common-tools'  %}
 
+# link to openldap-client so we can use state-exit data
+{#- Get the `tplroot` from `tpldir` #}
+{%- set tplroot = tpldir.split('/')[0] %}
+{%- set sls_package_install = tplroot ~ '.elx.openldap-client.find-collision' %}
+
+include:
+  - {{ sls_package_install }}
+
+
 install_sssd:
   pkg.installed:
     - allow_updates: True
@@ -76,5 +85,6 @@ join_realm-{{ join_domain.dns_name }}:
       - ini: 'fix_domain_separator'
       - file: 'domain_defaults-{{ join_domain.dns_name }}_ensure_permissions'
       - cmd: 'sssd-NETBIOSfix'
+      - cmd: 'LDAP-FindCollison'
     - source: 'salt://{{ joiner_files }}/join.sh'
     - unless: 'realm list | grep -qs {{ join_domain.dns_name }}'

--- a/join-domain/elx/sssd/init.sls
+++ b/join-domain/elx/sssd/init.sls
@@ -22,6 +22,8 @@ install_sssd:
   pkg.installed:
     - allow_updates: True
     - pkgs: {{ pkg_list }}
+    - require:
+      - cmd: 'LDAP-FindCollison'
 
 fix_domain_separator:
   ini.options_present:
@@ -85,6 +87,5 @@ join_realm-{{ join_domain.dns_name }}:
       - ini: 'fix_domain_separator'
       - file: 'domain_defaults-{{ join_domain.dns_name }}_ensure_permissions'
       - cmd: 'sssd-NETBIOSfix'
-      - cmd: 'LDAP-FindCollison'
     - source: 'salt://{{ joiner_files }}/join.sh'
     - unless: 'realm list | grep -qs {{ join_domain.dns_name }}'

--- a/pillar.example
+++ b/pillar.example
@@ -57,7 +57,15 @@ join-domain:
       - trusted.ad.domain2
       - ...
       - trusted.ad.domainn
-    tls_check: (Used for resolving stale-object collisions in directory-domains that don't support TLS)
+
+    # For detection of naming-collisions via LDAP tools
+    ldap_tls_mode:   Provide a hint to the collision-detection script for
+                     whether to use TLS when performing lookup and deletion
+                     activities. Valid values of 'require', 'try' or 'none';
+                     default value of 'try'.
+    ldap_fatal_exit: Whether a connection-failure during search or delete
+                     operation results in the search/delete functions exiting
+                     fatally or not. Valid values of 'true' or 'false'
 
     # AD-connector Tool
     ad_connector: [pbis|sssd]


### PR DESCRIPTION
This PR:

1. Changes how the `openldap-client` is `include`d in the join-domain workflow: instead of being called at the top-level (the `elx` layer), it is called by the `sssd` layer. This allows proper handling of error-exits from the `ldapsearch`  and `ldapdelete` operations
2. Allows error-exits from the `ldapsearch`  and `ldapdelete` operations to be either fatal or non-fatal to the overall `join-domain` workflow (set via `lldap_fatal_exit` pillar-variable).

Closes #190