### PR TITLE
add clean state to join domain

### DIFF
--- a/join-domain/elx/sssd/files/join.sh
+++ b/join-domain/elx/sssd/files/join.sh
@@ -51,6 +51,27 @@ function IsDiscoverable {
   fi
 }
 
+# Perform cleanup actions to leave the domain
+function CleanupDomain {
+  echo "Leaving the domain ..."
+  realm leave "${JOIN_DOMAIN}" || true
+
+# Remove DDNS records associated with the host
+  echo "Removing DDNS records..."
+  sss_dnsupdate -d
+
+# Delete specific files and configurations
+  echo "Cleaning up configuration files..."
+  rm -f "/etc/sssd/conf.d/${JOIN_DOMAIN}.conf"
+  rm -f "/etc/krb5.keytab"
+
+# Empty /etc/krb5.conf.d directory
+  echo "Emptying /etc/krb5.conf.d directory..."
+  rm -f "/etc/krb5.conf.d/*"
+
+  echo "Cleanup completed."
+}
+
 # Try to join host to domain
 function JoinDomain {
 
@@ -115,4 +136,5 @@ function JoinDomain {
 }
 
 IsDiscoverable
+CleanupDomain
 JoinDomain


### PR DESCRIPTION
Create a workflow that will reverse the changes made by the sssd directory’s automation. 

1. perform a realm leave
2. Ensure that any DDNS records associated with the host are nuked (or at least an attempt to nuke made)
3. ensure that the /etc/sssd/conf.d/<NETBIOS_DOMAIN>.conf and /etc/krb5.keytab files are deleted
4. ensure that the /etc/sssd/sssd.confand /etc/krb5.conf files are reverted to the same state they were when the sssd-common RPM was initially installed
5. The /etc/krb5.conf.d directory is emptied