### PR TITLE
Add conditional FIPS Posture-Relaxation Handler

### DIFF
--- a/join-domain/elx/sssd/init.sls
+++ b/join-domain/elx/sssd/init.sls
@@ -55,6 +55,18 @@ install_sssd:
     - require:
       - cmd: 'LDAP-FindCollison'
 
+fix_fascist_FIPS_mode:
+  cmd.run:
+    - name: 'update-crypto-policies --set FIPS:AD-SUPPORT'
+    - cwd: '/root'
+    - onlyif:
+      - 'if [[ {{ elMajor }} -ge 9 ]]'
+    - require:
+      - pkg: install_sssd
+    - shell: '/bin/bash'
+    - success_retcodes:
+      - 0
+
 fix_domain_separator:
   ini.options_present:
     - name: '/etc/sssd/sssd.conf'

--- a/join-domain/elx/sssd/init.sls
+++ b/join-domain/elx/sssd/init.sls
@@ -60,7 +60,7 @@ fix_fascist_FIPS_mode:
     - name: 'update-crypto-policies --set FIPS:AD-SUPPORT'
     - cwd: '/root'
     - onlyif:
-      - 'if [[ {{ elMajor }} -ge 9 ]]'
+      - '[[ {{ elMajor }} -ge 9 ]]'
     - require:
       - pkg: install_sssd
     - shell: '/bin/bash'
@@ -130,6 +130,7 @@ join_realm-{{ join_domain.dns_name }}:
       - ini: 'fix_domain_separator'
       - file: 'domain_defaults-{{ join_domain.dns_name }}_ensure_permissions'
       - cmd: 'sssd-NETBIOSfix'
+      - cmd: 'fix_fascist_FIPS_mode'
     - require_in:
       {%- if salt.state.sls_exists(pam_no_nullok) %}
       - cmd: 'Disable nullok module in PAM'

--- a/join-domain/elx/sssd/init.sls
+++ b/join-domain/elx/sssd/init.sls
@@ -9,6 +9,7 @@
 {%- set joiner_files = tpldir ~ '/files' %}
 {%- set common_tools = 'salt://' ~ salt.file.dirname(tpldir) ~ '/common-tools'  %}
 {%- set elMajor = salt.grains.get('osmajorrelease') | string %}
+{%- set krb5_sec_file = '/etc/crypto-policies/back-ends/krb5.config' %}
 {%- set pam_no_nullok =
           'ash-linux.el' +
           elMajor +
@@ -66,6 +67,10 @@ fix_fascist_FIPS_mode:
     - shell: '/bin/bash'
     - success_retcodes:
       - 0
+    - unless:
+      - '[[ ! -L {{ krb5_sec_file }} ]]'
+      - '[[ $( grep -qw aes256-cts-hmac-sha1-96 {{ krb5_sec_file }} )$? -eq 0 ]]'
+      - '[[ $( grep -qw aes128-cts-hmac-sha1-96 {{ krb5_sec_file }} )$? -eq 0 ]]'
 
 fix_domain_separator:
   ini.options_present:


### PR DESCRIPTION
Per the Red Hat [documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_identity-management_considerations-in-adopting-rhel-9#known-issues-identity-management_assembly_identity-management), in order to support AD-based authentication via the `realm` service, RHEL 9's FIPS-posture must be relaxed by executing:

```bash
update-crypto-policies --set FIPS:AD-SUPPORT
```

This PR adds this logic as a prep-step prior to attempting to execute `realm join …` on RHEL 9 (and higher) ELx distros. 

Closes #218
